### PR TITLE
fix(9522200,9522315): chain-setvar bug causing silent anomaly score on legit traffic

### DIFF
--- a/plugins/wordpress-hardening-before.conf
+++ b/plugins/wordpress-hardening-before.conf
@@ -496,10 +496,10 @@ SecRule REQUEST_FILENAME "@rx \.php$" \
   capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
   msg:'Wordpress hardening: attempt to access php files other than index.php',\
-  setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
   chain"
   SecRule REQUEST_FILENAME "!@rx ^(?:/wp-admin/|(?:.*/)?(?:index|xmlrpc|wp-cron|wp-login)\.php$)" \
-    "t:lowercase,t:normalizePath,t:trim"
+    "t:lowercase,t:normalizePath,t:trim,\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # No direct access to these files (PL1)
 SecRule REQUEST_FILENAME "@pmFromFile wordpress-hardening-files.data" \
@@ -880,10 +880,10 @@ SecRule REQUEST_URI "@beginsWith /wp-login.php" \
   capture,\
   logdata:'Matched injection in login param: %{MATCHED_VAR}',\
   msg:'Wordpress hardening: code injection detected in wp-login.php parameters',\
-  setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
   chain"
   SecRule ARGS:log|ARGS:pwd "@rx (?:<[^>]+>|script|alert\(|eval\(|base64_decode|onload=|onerror=)" \
-    "t:lowercase,t:htmlEntityDecode,t:urlDecodeUni"
+    "t:lowercase,t:htmlEntityDecode,t:urlDecodeUni,\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 SecMarker "END_WPHARD_BLOCK_LOGIN_INJECTION"
 

--- a/tests/security/wordpress-hardening-plugin/false-positives.yaml
+++ b/tests/security/wordpress-hardening-plugin/false-positives.yaml
@@ -39,7 +39,12 @@ tests:
             no_log_contains: id "9522
 
   - test_title: fp-admin-ajax
-    desc: Standard wp-admin/admin-ajax.php POST (heartbeat etc.) is legit.
+    desc: >
+      Standard wp-admin/admin-ajax.php POST (heartbeat etc.) is legit.
+      Regression for the chain-setvar bug in 9522200: the parent's setvar
+      previously fired unconditionally on any ".php$" match, scoring +5 even
+      when the chained allow-list check passed. Assert no anomaly score is
+      contributed (per_pl=0-0-0-0) in addition to no 9522 rule log line.
     stages:
       - stage:
           input:
@@ -54,9 +59,13 @@ tests:
             data: "action=heartbeat&_nonce=abc123&data=1"
           output:
             no_log_contains: id "9522
+            no_log_contains: "per_pl=[1-9]"
 
   - test_title: fp-wpcron-internal
-    desc: wp-cron.php from the loopback (internal WP self-call) is legit.
+    desc: >
+      wp-cron.php from the loopback (internal WP self-call) is legit.
+      Regression for the chain-setvar bug in 9522200: assert no anomaly
+      score is contributed in addition to no 9522 rule log line.
     stages:
       - stage:
           input:
@@ -70,6 +79,45 @@ tests:
             uri: /wp-cron.php?doing_wp_cron=1779142579.0
           output:
             no_log_contains: id "9522
+            no_log_contains: "per_pl=[1-9]"
+
+  - test_title: fp-wp-login-plain
+    desc: >
+      Plain GET of /wp-login.php is legit. Regression for the chain-setvar
+      bug in 9522315: the parent's setvar previously fired on any URI
+      beginning with "/wp-login.php", scoring +5 even when no injection was
+      present in ARGS:log/pwd. Assert no anomaly score and no rule log line.
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: Mozilla/5.0}
+            port: 80
+            method: GET
+            uri: /wp-login.php
+          output:
+            no_log_contains: id "9522
+            no_log_contains: "per_pl=[1-9]"
+
+  - test_title: fp-wp-login-normal-post
+    desc: >
+      Normal wp-login.php POST (no injection) is legit. Regression for
+      9522315 chain-setvar bug — assert no anomaly score contribution.
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: Mozilla/5.0
+              Content-Type: application/x-www-form-urlencoded
+            port: 80
+            method: POST
+            uri: /wp-login.php
+            data: "log=normaluser&pwd=correcthorsebatterystaple&wp-submit=Log+In"
+          output:
+            no_log_contains: id "9522
+            no_log_contains: "per_pl=[1-9]"
 
   - test_title: fp-wpjson-subpath-read
     desc: >


### PR DESCRIPTION
## Summary

Two rules in the plugin had a chain-logic bug: `setvar:tx.inbound_anomaly_score_pl1=+critical` was placed on the **parent** rule, before the `chain` action. libmodsecurity3 evaluates non-disruptive actions (including `setvar`) on parent match, independently of whether the chained child subsequently matches. The score therefore incremented unconditionally for *any* request the parent matched — including the paths the chained child explicitly allow-listed.

- **9522200** (PHP files other than index.php): parent matches `\.php\$`. Score fired on every `.php` request, including `/wp-admin/*`, `/index.php`, `/wp-cron.php`, `/xmlrpc.php`, `/wp-login.php`.
- **9522315** (wp-login.php code injection): parent matches `REQUEST_URI` beginsWith `/wp-login.php`. Score fired on every wp-login hit, regardless of injection presence.

A single PL1 critical hit (+5) is enough to exceed the default inbound threshold (5), so legitimate wp-cron, admin-ajax, and wp-login traffic was blocked by CRS 949110 — with **no** Warning log line carrying 9522200 / 9522315, because the chain's disruptive action (`block`) only fires on full chain match; only the silent `setvar` side-effect tripped 949110.

## Fix

Move the `setvar` action into the chained **child** rule's action list so the score is only incremented when the full chain matches.

## Why existing tests didn't catch it

`tests/security/.../false-positives.yaml` and the per-rule regression tests asserted `no_log_contains: id \"9522…\"` on legit traffic. That kept passing because the rules never logged their own match — only the side-effect on the anomaly score was the bug.

This PR extends `false-positives.yaml`:
- Adds `no_log_contains: \"per_pl=[1-9]\"` (CRS 980170's per-PL score breakdown) to the existing `fp-admin-ajax` and `fp-wpcron-internal` tests.
- Adds two new tests for the 9522315 false-positive: `fp-wp-login-plain` (GET) and `fp-wp-login-normal-post`.

## Reproducer

```
# Before fix
curl -sk -X POST -o /dev/null -w '%{http_code}\n' \\
    'https://example.invalid/wp-cron.php?doing_wp_cron=1'
# 302  (blocked by CRS 949110 — score=5 from 9522200's silent setvar)

# Debug log shows:
# (Rule: 9522200) Executing operator \"Rx\" with param \"\\.php\$\" against REQUEST_FILENAME
# Running [independent] (non-disruptive) action: setvar
# Saving variable: TX:inbound_anomaly_score_pl1 with value: 5
# (chain child returns 0 — i.e. wp-cron.php IS in the allow-list — but score already +5)
```

After this fix the same request returns 200 and the score stays at 0.

## Test plan

- [ ] CI passes (regression + security FTW corpus)
- [ ] Manual: `curl https://<site>/wp-cron.php?doing_wp_cron=1` returns 200 (not 302)
- [ ] Manual: `curl https://<site>/wp-admin/admin-ajax.php` reaches WP (400 from WP business logic, not 302 from CRS)
- [ ] Manual: `curl https://<site>/wp-login.php` reaches WP login page
- [ ] Regression: scanner probes (`/.env`, `/wp-content/uploads/shell.php`, real `/xmlrpc.php`) still blocked