### PR TITLE
audit: correctness, perf, RFC, IPv6 + log-driven fixes

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -5,13 +5,21 @@ For official CRS plugin installation instructions, see https://coreruleset.org/d
 File Path Configuration
 =====================
 
-This plugin uses @pmFromFile for efficient pattern matching. The `wordpress-hardening-files.data` file must be:
+This plugin uses @pmFromFile / @ipMatchFromFile for efficient pattern matching.
+The following .data files must all be deployed alongside the .conf files (or
+referenced with an absolute path):
 
-1. Placed in the same directory as `wordpress-hardening-before.conf`, OR
-2. Placed in ModSecurity's configured rules directory, OR
-3. Referenced with an absolute path in the rules file
+  - wordpress-hardening-files.data            (direct-access block list)
+  - wordpress-hardening-scanners.data         (scanner UA block list, PL2)
+  - wordpress-hardening-login-countries.data  (GeoIP allow list — LOWERCASE)
+  - wordpress-hardening-ip-reputation.data    (IP reputation block list)
+  - wordpress-hardening-trusted-proxies.data  (XFF trusted-proxy CIDRs)
 
-If loading rules from a different path, ensure the .data file is accessible or update the @pmFromFile reference:
-  @pmFromFile /full/path/to/wordpress-hardening-files.data
+The files must be in one of:
+
+1. The same directory as `wordpress-hardening-before.conf`, OR
+2. ModSecurity's configured rules directory, OR
+3. Referenced with an absolute path in the rules file:
+     @pmFromFile /full/path/to/wordpress-hardening-files.data
 
 See [README](README.md) for complete installation documentation.

--- a/README.md
+++ b/README.md
@@ -30,20 +30,45 @@ What this plugin does so far:
 - Block XDebug and phpinfo debug probe parameters (configurable, default: block) (PL1)
 - Block code injection patterns in wp-login.php POST parameters (configurable, default: block) (PL1)
 - Block dangerous wp-admin endpoints like install.php and setup-config.php (configurable, default: non-block) (PL2)
-- IP-based rate limiting for wp-login.php (configurable, default: 5 attempts per 60 seconds) (PL1)
+- IP-based rate limiting for wp-login.php (configurable, default: 5 attempts per 60 seconds, replies with HTTP 429 per RFC 6585) (PL1)
 - GeoIP-based access control for wp-login.php (configurable, default: disabled) (PL1)
 - Automatic IP reputation blocklist blocking all requests from listed IPs/CIDRs (configurable, default: disabled) (PL1)
+- Trusted-proxy pinning for X-Forwarded-For (configurable, default: disabled — backward compatible) (PL1)
+- IPv6-aware client-IP resolution and private-network whitelisting (loopback + RFC 1918 + IPv6 `::1` + ULA `fc00::/7`)
 
 ## IP Whitelisting
 
-The blocked endpoints (`xmlrpc.php`, `wp-json`, `wp-cron.php`) allow traffic from localhost and RFC 1918 private IP ranges by default:
+The blocked endpoints (`xmlrpc.php`, `wp-json`, `wp-cron.php`), the rate-limit counter, the GeoIP login gate, and the IP-reputation blocklist all share a **single** client-IP resolver and a **single** "is-this-a-private-IP?" decision, so the same identity is used everywhere.
 
-- `127.0.0.0/8` (localhost)
-- `10.0.0.0/8` (private)
-- `172.16.0.0/12` (private)
-- `192.168.0.0/16` (private)
+Whitelisted by default:
 
-This allows internal systems (cron jobs, monitoring, load balancers) to access these endpoints while blocking external attacks. You can customize the whitelist per endpoint in `wordpress-hardening-config.conf` (see the examples provided).
+- `127.0.0.0/8` (IPv4 loopback)
+- `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` (IPv4 RFC 1918)
+- `::1` (IPv6 loopback)
+- `fc00::/7` (IPv6 Unique Local addresses, RFC 4193)
+
+This allows internal systems (cron jobs, monitoring, load balancers) to access these endpoints while blocking external attacks.
+
+### Client-IP resolution
+
+`tx.wphard.client_ip` is built in phase 1 as follows:
+
+1. Default to `REMOTE_ADDR` (the directly-connected peer).
+2. If `X-Forwarded-For` is present **and trusted** (see [Trusted-Proxy Pinning](#trusted-proxy-pinning) below), take the leftmost hop. IPv4 and IPv6 first hops are both recognised; malformed values like `1.2.3.4junk` are rejected.
+
+### Trusted-Proxy Pinning
+
+By default the plugin honours `X-Forwarded-For` unconditionally — this is backward compatible and correct for any deployment behind a single trusted proxy (Cloudflare, nginx with `set_real_ip_from`, HAProxy). On a server with direct internet exposure, an attacker can otherwise spoof `X-Forwarded-For` and bypass the private-IP whitelist or rotate the rate-limit key.
+
+To eliminate that footgun:
+
+1. Populate `plugins/wordpress-hardening-trusted-proxies.data` with the public CIDRs of your real upstream proxies (one per line).
+2. Enable pinning in `plugins/wordpress-hardening-config.conf`:
+   ```bash
+   SecAction "id:9522055,phase:1,nolog,pass,t:none,setvar:'tx.wphard.trusted_proxies_enabled=1'"
+   ```
+
+When enabled, `X-Forwarded-For` is honoured **only** if `REMOTE_ADDR` is in that list; otherwise the resolver falls back to `REMOTE_ADDR`.
 
 ## Configuration
 
@@ -56,30 +81,52 @@ All features are **enabled by default** with sensible defaults. To override defa
 The plugin includes IP-based rate limiting for `wp-login.php` to prevent brute force attacks.
 
 **How it works:**
-- Tracks all POST requests to `/wp-login.php` per IP address
+- Tracks all POST requests to `/wp-login.php` per resolved client IP
 - Locks out an IP after exceeding the attempt threshold
-- Whitelist prevents rate limiting for trusted IPs (localhost + RFC 1918 by default)
+- Whitelist prevents rate limiting for trusted IPs (loopback + private ranges, IPv4 and IPv6)
+- Blocks return **HTTP 429 Too Many Requests** (RFC 6585 §4) and export `wphard_retry_after` as an env var so the webserver can add a `Retry-After` header to the response
 
 **Default settings:**
 - **Enabled by default** (`ratelimit_login_enabled`)
 - **5 login attempts** per IP (`ratelimit_login_attempts`)
 - **60 second window** (`ratelimit_login_window`)
-- **Whitelisted IPs**: `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+- **Whitelisted IPs**: see [IP Whitelisting](#ip-whitelisting) above
 
 **Customization:**
 
 Uncomment these in `plugins/wordpress-hardening-config.conf` to override defaults:
 
 ```bash
-# Reduce to 3 attempts per 30 seconds
-#SecAction "id:9522051,phase:1,nolog,pass,t:none,setvar:tx.wphard.ratelimit_login_attempts=3"
-#SecAction "id:9522053,phase:1,nolog,pass,t:none,setvar:tx.wphard.ratelimit_login_window=30"
+# Reduce to 3 attempts
+#SecAction "id:9522049,phase:1,nolog,pass,t:none,setvar:tx.wphard.ratelimit_login_attempts=3"
 
-# Add datacenter IPs to whitelist (space-separated CIDR, spaces as %20)
-#SecAction "id:9522055,phase:1,nolog,pass,t:none,setvar:tx.wphard.ratelimit_login_whitelist_ips=127.0.0.0/8%20 10.0.0.0/8%20 172.16.0.0/12%20 192.168.0.0/16%20 203.0.113.0/24"
+# Change the window (allowed values: 30, 60, 120, 300, 600 — any other value
+# silently falls back to 60s)
+#SecAction "id:9522050,phase:1,nolog,pass,t:none,setvar:tx.wphard.ratelimit_login_window=300"
 
 # Disable rate limiting entirely
-#SecAction "id:9522049,phase:1,nolog,pass,t:none,setvar:tx.wphard.ratelimit_login_enabled=0"
+#SecAction "id:9522048,phase:1,nolog,pass,t:none,setvar:tx.wphard.ratelimit_login_enabled=0"
+```
+
+> **Note on the window:** `expirevar` in ModSecurity does not accept macro
+> expansion in its TTL, so the plugin dispatches the configured window through
+> five literal `expirevar` rules (rule IDs `9522416`-`9522420`) covering 30, 60,
+> 120, 300, and 600 seconds. Any other value falls back to 60s.
+
+### `Retry-After` response header (optional)
+
+Rule `9522412` calls `setenv:wphard_retry_after=<seconds>` whenever it blocks
+with 429. To expose that as an HTTP response header, add the following to your
+webserver config:
+
+**nginx / Angie:**
+```nginx
+add_header Retry-After $wphard_retry_after always;
+```
+
+**Apache (with mod_security2):**
+```apache
+Header always set Retry-After "%{wphard_retry_after}e" env=wphard_retry_after
 ```
 
 ## GeoIP-Based Access Control for wp-login.php
@@ -102,28 +149,30 @@ Blocks access to `wp-login.php` for clients from countries not in the allowed li
    ```bash
    SecAction "id:9522052,phase:1,nolog,pass,t:none,setvar:'tx.wphard.geoip_login_enabled=1'"
    ```
-2. Populate `plugins/wordpress-hardening-login-countries.data` with the ISO codes of countries you want to allow (one per line):
+2. Populate `plugins/wordpress-hardening-login-countries.data` with the ISO codes of countries you want to allow (**lowercase, one per line**):
    ```
-   NL
-   DE
-   GB
+   nl
+   de
+   gb
    ```
+
+   > **⚠️ Case matters.** The country header is normalised to lowercase before lookup, and `@pmFromFile` is case-sensitive. Adding `NL` (uppercase) means the allow-list never matches and every login is blocked.
 
 ## IP Reputation Blocklist
 
 Blocks **all requests** (not just login attempts) from IP addresses listed in `plugins/wordpress-hardening-ip-reputation.data`. Supports individual IPs and CIDR ranges. No external API or database required — the blocklist is a plain text file you populate from threat intelligence feeds or your own data.
 
 **How it works:**
-- Client IP sourced from `X-Forwarded-For` (preferred, for proxied traffic) or `REMOTE_ADDR`
+- Uses the shared resolved client IP (`tx.wphard.client_ip`) — see [Client-IP resolution](#client-ip-resolution) above
 - Uses ModSecurity's `@ipMatchFromFile` operator — supports IPv4, IPv6, and CIDR notation
-- Loopback and RFC 1918 addresses are always whitelisted
+- Loopback and private ranges (IPv4 RFC 1918 + IPv6 `::1` and ULA `fc00::/7`) are always whitelisted
 - Applies globally (all URIs, not just `wp-login.php`)
 
 **Default settings:**
 - **Disabled by default** (`ip_reputation_enabled=0`)
 - Data file ships with `192.0.2.0/24` (RFC 5737 documentation range used for CI tests) — replace with real entries in production
 
-> **Security note:** `X-Forwarded-For` is trusted unconditionally. Only enable this feature behind a proxy that controls the header.
+> **Security note:** `X-Forwarded-For` is trusted by default. For deployments without a proxy in front, enable [trusted-proxy pinning](#trusted-proxy-pinning) before turning this feature on, or attackers can rotate XFF to evade the blocklist.
 
 **To enable:**
 1. Uncomment the SecAction in `plugins/wordpress-hardening-config.conf`:
@@ -142,10 +191,29 @@ Blocks **all requests** (not just login attempts) from IP addresses listed in `p
 - [Emerging Threats](https://rules.emergingthreats.net/fwrules/) — compromised host blocklists
 - [Firehol Level 1](https://raw.githubusercontent.com/firehol/blocklist-ipsets/master/firehol_level1.netset) — aggregated reputation feed
 
+## Rule ID Map
+
+The plugin uses the allocated range **9522000-9522999**. Major buckets:
+
+| Range | Purpose |
+|---|---|
+| `9522010`-`9522055` | Config-knob `SecAction`s (commented examples in `config.conf`) |
+| `9522012`-`9522050` | Default-value setters (in `before.conf`) |
+| `9522060`-`9522065` | Client-IP resolver (`REMOTE_ADDR`, XFF v4/v6, trusted-proxy gate, `client_is_private`) |
+| `9522099` | Plugin kill-switch (removes 9522000-9522998) |
+| `9522101`-`9522111` | xmlrpc / user-enumeration / REST API / admin-login / wp-cron blocks |
+| `9522150`-`9522155` | Per-group whitelist (uses `client_is_private`) |
+| `9522199`-`9522207` | Static-asset fast path, direct-PHP guard, files.data, uploads, sensitive files |
+| `9522300`-`9522320` | Editor / backup / DB / upload-traversal / null-byte / scanner / debug / login-injection / dangerous-admin |
+| `9522400`-`9522420` | Rate-limit gate, counter, window dispatcher, 429 block |
+| `9522500`-`9522510` | GeoIP header extraction + login gate |
+| `9522600`-`9522604` | IP reputation gate, whitelist, block |
+
 ## Future Features (Raincheck list)
 
 These features are planned but not yet implemented:
 - IP-based rate limiting for other endpoints (wp-admin, xmlrpc, etc.)
+- Native `Retry-After` header injection (today requires a one-line webserver snippet — see [Rate Limiting](#ip-based-rate-limiting))
 
 ## Requirements
 - CRS Version 4.0 or newer

--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ The plugin includes IP-based rate limiting for `wp-login.php` to prevent brute f
 - Whitelist prevents rate limiting for trusted IPs (loopback + private ranges, IPv4 and IPv6)
 - Blocks return **HTTP 429 Too Many Requests** (RFC 6585 §4) and export `wphard_retry_after` as an env var so the webserver can add a `Retry-After` header to the response
 
+> **⚠️ Engine support:** rate limiting relies on persistent collections
+> (`initcol:ip=...` + `IP:` variables). This works reliably on **Apache +
+> mod_security2 (v2.x)**. **libmodsecurity3 (the engine used by nginx /
+> Angie)** has long-standing gaps in its persistent-collection
+> implementation — the counter often never persists across requests and
+> the rate-limit never triggers, even when the rule itself parses and
+> loads correctly. If you're on libmodsec3, prefer your webserver's
+> native rate-limiter (e.g. nginx/Angie's `limit_req zone=...`) for
+> `/wp-login.php` and treat this plugin's rate-limiter as Apache-only.
+
 **Default settings:**
 - **Enabled by default** (`ratelimit_login_enabled`)
 - **5 login attempts** per IP (`ratelimit_login_attempts`)

--- a/plugins/wordpress-hardening-before.conf
+++ b/plugins/wordpress-hardening-before.conf
@@ -20,6 +20,19 @@
 # This allows internal systems (cron jobs, monitoring, load balancers) to function.
 # Customize per-endpoint in wordpress-hardening-config.conf if needed.
 
+# CRITICAL: default-set the enable flag to 1 if no operator has explicitly
+# disabled the plugin (the disable example in config.conf sets it to 0). This
+# follows the standard CRS plugin template. Previously this rule was missing
+# and the kill-switch (9522099) fired on EVERY request because @eq 0 against
+# an unset variable evaluates to true in ModSecurity — silently disabling the
+# plugin in production.
+SecRule &TX:wordpress-hardening-plugin_enabled "@eq 0" \
+  "id:9522098,\
+  phase:1,\
+  pass,\
+  nolog,\
+  setvar:tx.wordpress-hardening-plugin_enabled=1"
+
 #Generic rule to disable plugin.
 # S7 fix: the range now covers the whole allocated block (9522000-9522999)
 # except this rule itself, so a future low-ID rule cannot silently survive the

--- a/plugins/wordpress-hardening-before.conf
+++ b/plugins/wordpress-hardening-before.conf
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------
 
 # OWASP CRS Plugin
-# Plugin name: wordpress-hardering-plugin
+# Plugin name: wordpress-hardening-plugin
 # Plugin description: harden wordpress, minimize php/sql impact
 # Rule ID block base: 9,522,000-9,522,999
 # Plugin version: 1.0.0
@@ -194,6 +194,18 @@ SecRule &TX:wphard.ip_reputation_enabled "@eq 0" \
   nolog,\
   setvar:tx.wphard.ip_reputation_enabled=0"
 
+# Default: trusted_proxies_enabled OFF. When OFF, X-Forwarded-For is honoured
+# regardless of REMOTE_ADDR (backward compatible). When ON, the operator must
+# populate plugins/wordpress-hardening-trusted-proxies.data with the CIDRs of
+# their real upstream proxies; XFF will then be honoured ONLY when REMOTE_ADDR
+# matches that list. Closes the "deployed without a real proxy" footgun.
+SecRule &TX:wphard.trusted_proxies_enabled "@eq 0" \
+  "phase:1,\
+  id:9522050,\
+  pass,\
+  nolog,\
+  setvar:tx.wphard.trusted_proxies_enabled=0"
+
 # Phase 1: Extract the country code from known proxy headers.
 # Priority: CF-IPCountry (Cloudflare) > X-GeoIP-Country (generic).
 # Result is stored in TX:wphard.geoip_country for use in phase 2.
@@ -242,17 +254,67 @@ SecAction \
   nolog,\
   setvar:tx.wphard.client_ip=%{REMOTE_ADDR}"
 
-# First hop of XFF only: ^\s*<ipv4> up to the first comma. Capture group 1 is
-# the candidate; the @rx anchors at start so trailing ", proxy, proxy" is
-# excluded. The IPv4 octet pattern rejects malformed values.
-SecRule REQUEST_HEADERS:X-Forwarded-For \
-  "@rx ^\s*((?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(?:\.(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3})" \
+# Trusted-proxy gate. Default tx.wphard.xff_trusted=1 (XFF honoured), then if
+# tx.wphard.trusted_proxies_enabled is ON, downgrade to 0 unless REMOTE_ADDR
+# is in the trusted_proxies data file. This means an operator who turns the
+# feature ON gets explicit pinning; everyone else gets the prior behaviour.
+SecAction \
+  "id:9522064,\
+  phase:1,\
+  pass,\
+  nolog,\
+  setvar:tx.wphard.xff_trusted=1"
+
+SecRule TX:wphard.trusted_proxies_enabled "@eq 1" \
+  "id:9522065,\
+  phase:1,\
+  pass,\
+  nolog,\
+  chain"
+  SecRule REMOTE_ADDR "!@ipMatchFromFile wordpress-hardening-trusted-proxies.data" \
+    "setvar:tx.wphard.xff_trusted=0"
+
+# First hop of XFF only: ^\s*<ipv4> followed by a clean terminator (comma,
+# whitespace, or end-of-string). Capture group 1 is the candidate. The trailing
+# (?=...) lookahead rejects malformed first hops like "1.2.3.4junk" — previously
+# the regex would silently accept them and set client_ip to the prefix.
+# Gated on xff_trusted so an operator with trusted_proxies_enabled=1 cannot be
+# fooled by XFF from a non-upstream peer.
+SecRule TX:wphard.xff_trusted "@eq 1" \
   "id:9522061,\
   phase:1,\
   pass,\
   nolog,\
-  capture,\
-  setvar:tx.wphard.client_ip=%{TX.1}"
+  chain"
+  SecRule REQUEST_HEADERS:X-Forwarded-For \
+    "@rx ^\s*((?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(?:\.(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3})(?=$|[\s,])" \
+    "capture,setvar:tx.wphard.client_ip=%{TX.1}"
+
+# IPv6 first hop of XFF. Pattern grammar is intentionally permissive (hex
+# groups, ::, IPv4-mapped tail) but bounded — every alternative is anchored
+# to ^\s* and stops at a [\s,] / end-of-string terminator. Also gated on
+# xff_trusted.
+SecRule TX:wphard.xff_trusted "@eq 1" \
+  "id:9522062,\
+  phase:1,\
+  pass,\
+  nolog,\
+  chain"
+  SecRule REQUEST_HEADERS:X-Forwarded-For \
+    "@rx ^\s*(\[?(?:(?:[0-9A-Fa-f]{1,4}:){1,7}[0-9A-Fa-f]{1,4}|(?:[0-9A-Fa-f]{1,4}:){1,7}:|::(?:[0-9A-Fa-f]{1,4}:){0,6}[0-9A-Fa-f]{1,4}|::1?|(?:[0-9A-Fa-f]{1,4}:){1,6}(?:\d{1,3}\.){3}\d{1,3})\]?)(?=$|[\s,])" \
+    "capture,setvar:tx.wphard.client_ip=%{TX.1}"
+
+# Phase-1 helper: classify the resolved client_ip as "private" (loopback +
+# RFC 1918 for v4, plus IPv6 loopback ::1 and Unique Local fc00::/7) and store
+# the result in tx.wphard.client_is_private. This collapses the six identical
+# whitelist regexes into a single check, and gives every group an IPv6-aware
+# private-network test for free.
+SecRule TX:wphard.client_ip "@rx ^(?:127\.[0-9]+\.[0-9]+\.[0-9]+|10\.[0-9]+\.[0-9]+\.[0-9]+|172\.(?:1[6-9]|2[0-9]|3[01])\.[0-9]+\.[0-9]+|192\.168\.[0-9]+\.[0-9]+|\[?::1\]?|\[?[fF][cCdD][0-9A-Fa-f]{2}:.*\]?)$" \
+  "id:9522063,\
+  phase:1,\
+  pass,\
+  nolog,\
+  setvar:tx.wphard.client_is_private=1"
 
 # Check if xmlrpc should be blocked and if not, skip.
 SecRule &TX:wphard.block_xmlrpc "@eq 0" \
@@ -267,14 +329,14 @@ SecRule &TX:wphard.block_xmlrpc "@eq 0" \
 # is consistent with the rate-limit key and is immune to multi-value/malformed
 # X-Forwarded-For smuggling. Rule 9522153 retained as a no-op marker so the
 # rule-ID inventory and chained-rule structure stay stable for CI.
-SecRule TX:wphard.client_ip "@rx ^(127\.[0-9]+\.[0-9]+\.[0-9]+|10\.[0-9]+\.[0-9]+\.[0-9]+|172\.(1[6-9]|2[0-9]|3[01])\.[0-9]+\.[0-9]+|192\.168\.[0-9]+\.[0-9]+)$" \
+SecRule TX:wphard.client_is_private "@eq 1" \
   "id:9522150,\
   phase:2,\
   pass,\
   nolog,\
   skipAfter:END_WPHARD_XMLRPC"
 
-SecRule TX:wphard.client_ip "@rx ^127\.0\.0\.1$" \
+SecRule TX:wphard.client_ip "@rx ^__never_match__$" \
   "id:9522153,\
   phase:2,\
   pass,\
@@ -340,14 +402,14 @@ SecRule TX:wphard.block_rest_api "@eq 0" \
   skipAfter:END_WPHARD_BLOCK_REST_API"
 
 # Skip if the resolved trusted client IP is whitelisted (localhost + RFC 1918).
-SecRule TX:wphard.client_ip "@rx ^(127\.[0-9]+\.[0-9]+\.[0-9]+|10\.[0-9]+\.[0-9]+\.[0-9]+|172\.(1[6-9]|2[0-9]|3[01])\.[0-9]+\.[0-9]+|192\.168\.[0-9]+\.[0-9]+)$" \
+SecRule TX:wphard.client_is_private "@eq 1" \
   "id:9522151,\
   phase:2,\
   pass,\
   nolog,\
   skipAfter:END_WPHARD_BLOCK_REST_API"
 
-SecRule TX:wphard.client_ip "@rx ^127\.0\.0\.1$" \
+SecRule TX:wphard.client_ip "@rx ^__never_match__$" \
   "id:9522155,\
   phase:2,\
   pass,\
@@ -403,7 +465,8 @@ SecRule REQUEST_URI "@beginsWith /wp-login.php" \
   msg:'Wordpress hardening: admin login attempt detected',\
     chain"
     SecRule ARGS:log|ARGS:pwd "@streq admin" \
-    "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    "t:lowercase,t:trim,\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 SecMarker "END_WPHARD_BLOCK_ADMIN_LOGIN"
 
@@ -416,14 +479,14 @@ SecRule TX:wphard.block_wpcron "@eq 0" \
   skipAfter:END_WPHARD_WPCRON"
 
 # Skip if the resolved trusted client IP is whitelisted (localhost + RFC 1918).
-SecRule TX:wphard.client_ip "@rx ^(127\.[0-9]+\.[0-9]+\.[0-9]+|10\.[0-9]+\.[0-9]+\.[0-9]+|172\.(1[6-9]|2[0-9]|3[01])\.[0-9]+\.[0-9]+|192\.168\.[0-9]+\.[0-9]+)$" \
+SecRule TX:wphard.client_is_private "@eq 1" \
   "id:9522152,\
   phase:2,\
   pass,\
   nolog,\
   skipAfter:END_WPHARD_WPCRON"
 
-SecRule TX:wphard.client_ip "@rx ^127\.0\.0\.1$" \
+SecRule TX:wphard.client_ip "@rx ^__never_match__$" \
   "id:9522154,\
   phase:2,\
   pass,\
@@ -498,7 +561,7 @@ SecRule REQUEST_FILENAME "@rx \.php$" \
   msg:'Wordpress hardening: attempt to access php files other than index.php',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}',\
   chain"
-  SecRule REQUEST_FILENAME "!@rx ^(?:/wp-admin/|(?:.*/)?(?:index|xmlrpc|wp-cron|wp-login)\.php$)" \
+  SecRule REQUEST_FILENAME "!@rx ^(?:/wp-admin/|/(?:index|xmlrpc|wp-cron|wp-login|wp-comments-post|wp-signup)\.php$)" \
     "t:lowercase,t:normalizePath,t:trim"
 
 # No direct access to these files (PL1)
@@ -657,7 +720,12 @@ SecRule TX:wphard.block_backup_files "@eq 0" \
 
 SecMarker "BEGIN_WPHARD_BLOCK_BACKUP_FILES"
 
-SecRule REQUEST_FILENAME "@rx ^/(?:backups?|db-backup|site-backup|wordpress-backup|backup-db)/|/wp-content/(?:backups?|backup)/|[-_]backup[-_]|\.(?:tar\.gz|tar\.bz2|tgz)(?:$|/)" \
+# NOTE: the [-_]backup[-_] sub-pattern was previously matching legitimate plugin
+# slugs (e.g. /wp-content/plugins/some-backup-plugin/style.css). It is now
+# anchored so it only fires when the "-backup-" / "_backup_" token is followed
+# by a backup-like extension (.zip/.tar*/.sql*/.dump/.bak), preventing the
+# false positive while keeping coverage for actual exposed dump files.
+SecRule REQUEST_FILENAME "@rx ^/(?:backups?|db-backup|site-backup|wordpress-backup|backup-db)/|/wp-content/(?:backups?|backup)/|[-_]backup[-_][^/]*\.(?:zip|tar(?:\.(?:gz|bz2|xz))?|tgz|sql(?:\.(?:gz|bz2|zip))?|dump|bak)(?:$|/)|\.(?:tar\.gz|tar\.bz2|tgz)(?:$|/)" \
   "id:9522303,\
   phase:2,\
   t:lowercase,t:normalizePath,t:trim,\
@@ -835,7 +903,10 @@ SecRule TX:wphard.block_debug_probes "@eq 0" \
 
 SecMarker "BEGIN_WPHARD_BLOCK_DEBUG_PROBES"
 
-SecRule REQUEST_URI|ARGS_NAMES "@rx XDEBUG_SESSION(_(START|STOP))?|XDEBUG_PROFILE|XDEBUG_TRACE|phpinfo" \
+# "phpinfo" was previously a free substring match — any post slug containing
+# the word triggered the block. Anchor it to either an exact arg-name match or
+# a /phpinfo(.php)? URI segment so legitimate content slugs are not blocked.
+SecRule REQUEST_URI|ARGS_NAMES "@rx XDEBUG_SESSION(?:_(?:START|STOP))?|XDEBUG_PROFILE|XDEBUG_TRACE|(?:^|/)phpinfo(?:\.php)?(?:$|[/?])|(?:^|&)phpinfo(?:=|$)" \
   "id:9522313,\
   phase:2,\
   t:lowercase,t:urlDecodeUni,\
@@ -950,14 +1021,14 @@ SecMarker "BEGIN_WPHARD_RATELIMIT_LOGIN"
 
 # Skip rate limiting for whitelisted client IPs (localhost + RFC 1918), using
 # the resolved trusted client IP (consistent with the counter key below).
-SecRule TX:wphard.client_ip "@rx ^(127\.[0-9]+\.[0-9]+\.[0-9]+|10\.[0-9]+\.[0-9]+\.[0-9]+|172\.(1[6-9]|2[0-9]|3[01])\.[0-9]+\.[0-9]+|192\.168\.[0-9]+\.[0-9]+)$" \
+SecRule TX:wphard.client_is_private "@eq 1" \
   "id:9522410,\
   phase:2,\
   pass,\
   nolog,\
   skipAfter:END_WPHARD_RATELIMIT_LOGIN"
 
-SecRule TX:wphard.client_ip "@rx ^127\.0\.0\.1$" \
+SecRule TX:wphard.client_ip "@rx ^__never_match__$" \
   "id:9522413,\
   phase:2,\
   pass,\
@@ -970,15 +1041,28 @@ SecRule TX:wphard.client_ip "@rx ^127\.0\.0\.1$" \
 # 5-strike lockout (DoS) AND an XFF-rotating attacker was uncounted. Keying on
 # tx.wphard.client_ip makes the limiter count the same identity the whitelist
 # trusts. initcol must run before any ip: read/write.
-SecAction \
+#
+# Perf gate: initcol persists the IP collection to disk (SDBM) on every call.
+# Previously this ran on EVERY phase-2 request when rate limiting was enabled
+# (every static asset, every page view). The chain below restricts initcol to
+# the only request shape the limiter actually keys on — POST to /wp-login.php
+# — so the dominant request path pays zero collection cost.
+SecRule REQUEST_METHOD "@streq POST" \
   "id:9522414,\
   phase:2,\
   pass,\
   nolog,\
-  initcol:ip=%{tx.wphard.client_ip}"
+  t:lowercase,\
+  chain"
+  SecRule REQUEST_URI "@endsWith /wp-login.php" \
+    "t:lowercase,t:normalizePath,\
+    initcol:ip=%{tx.wphard.client_ip}"
 
 # Track login attempts: increment the per-client counter on POST to wp-login.
-# Counter expires after a fixed 60s window (expirevar cannot take a macro TTL).
+# expirevar cannot take a macro TTL, so we dispatch on the configured window
+# value to one of five well-known buckets (30/60/120/300/600 seconds). Any
+# other value falls back to 60s. This honours tx.wphard.ratelimit_login_window
+# end-to-end instead of silently ignoring it.
 SecRule REQUEST_METHOD "@streq POST" \
   "id:9522411,\
   phase:2,\
@@ -991,12 +1075,31 @@ SecRule REQUEST_METHOD "@streq POST" \
   SecRule REQUEST_URI "@endsWith /wp-login.php" \
     "t:lowercase,t:normalizePath,\
     setvar:ip.login_attempts=+1,\
-    expirevar:ip.login_attempts=60,\
     capture"
+
+# Window dispatcher. Each @streq is a literal so no macro is needed; the
+# rule fires only when the configured window matches that bucket, sets the
+# expirevar accordingly, and skips the rest. The trailing SecAction handles
+# the 60s default + any unknown value.
+SecRule TX:wphard.ratelimit_login_window "@streq 30" \
+  "id:9522416,phase:2,pass,nolog,expirevar:ip.login_attempts=30,skipAfter:END_WPHARD_WINDOW_DISPATCH"
+SecRule TX:wphard.ratelimit_login_window "@streq 120" \
+  "id:9522417,phase:2,pass,nolog,expirevar:ip.login_attempts=120,skipAfter:END_WPHARD_WINDOW_DISPATCH"
+SecRule TX:wphard.ratelimit_login_window "@streq 300" \
+  "id:9522418,phase:2,pass,nolog,expirevar:ip.login_attempts=300,skipAfter:END_WPHARD_WINDOW_DISPATCH"
+SecRule TX:wphard.ratelimit_login_window "@streq 600" \
+  "id:9522419,phase:2,pass,nolog,expirevar:ip.login_attempts=600,skipAfter:END_WPHARD_WINDOW_DISPATCH"
+SecAction \
+  "id:9522420,phase:2,pass,nolog,expirevar:ip.login_attempts=60"
+SecMarker "END_WPHARD_WINDOW_DISPATCH"
 
 SecMarker "WPHARD_RATELIMIT_LOGIN_CHECK"
 
 # Block if login attempts exceed threshold for this client IP
+# RFC 6585 §4: rate-limit responses SHOULD use 429 Too Many Requests, not the
+# generic CRS-default deny status (403). We deny directly with status:429 so
+# callers can distinguish "you are throttled" from "request denied" and apply
+# backoff. The anomaly score is still incremented for log correlation.
 SecRule IP:login_attempts "@ge %{tx.wphard.ratelimit_login_attempts}" \
   "id:9522412,\
   phase:2,\
@@ -1008,9 +1111,10 @@ SecRule IP:login_attempts "@ge %{tx.wphard.ratelimit_login_attempts}" \
   maturity:'1',\
   severity:'WARNING',\
   ver:'WPHARD/1.0.0',\
-  block,\
+  deny,status:429,\
   capture,\
-  logdata:'Client IP: %{tx.wphard.client_ip}, Attempts: %{IP:login_attempts}, Threshold: %{tx.wphard.ratelimit_login_attempts}, Window: 60s fixed',\
+  setenv:'wphard_retry_after=%{tx.wphard.ratelimit_login_window}',\
+  logdata:'Client IP: %{tx.wphard.client_ip}, Attempts: %{IP:login_attempts}, Threshold: %{tx.wphard.ratelimit_login_attempts}, Window: %{tx.wphard.ratelimit_login_window}s',\
   msg:'Wordpress hardening: wp-login.php rate limit exceeded for IP',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -1054,14 +1158,14 @@ SecRule REQUEST_FILENAME "!@endsWith /wp-login.php" \
 
 # Whitelist: skip GeoIP check for the resolved trusted client IP if it is
 # localhost or RFC 1918.
-SecRule TX:wphard.client_ip "@rx ^(127\.[0-9]+\.[0-9]+\.[0-9]+|10\.[0-9]+\.[0-9]+\.[0-9]+|172\.(1[6-9]|2[0-9]|3[01])\.[0-9]+\.[0-9]+|192\.168\.[0-9]+\.[0-9]+)$" \
+SecRule TX:wphard.client_is_private "@eq 1" \
   "id:9522506,\
   phase:2,\
   pass,\
   nolog,\
   skipAfter:END_WPHARD_GEOIP_LOGIN"
 
-SecRule TX:wphard.client_ip "@rx ^127\.0\.0\.1$" \
+SecRule TX:wphard.client_ip "@rx ^__never_match__$" \
   "id:9522507,\
   phase:2,\
   pass,\
@@ -1118,14 +1222,14 @@ SecRule TX:wphard.ip_reputation_enabled "@eq 0" \
   skipAfter:END_WPHARD_IP_REPUTATION"
 
 # Whitelist: skip if the resolved trusted client IP is loopback or RFC 1918.
-SecRule TX:wphard.client_ip "@rx ^(127\.[0-9]+\.[0-9]+\.[0-9]+|10\.[0-9]+\.[0-9]+\.[0-9]+|172\.(1[6-9]|2[0-9]|3[01])\.[0-9]+\.[0-9]+|192\.168\.[0-9]+\.[0-9]+)$" \
+SecRule TX:wphard.client_is_private "@eq 1" \
   "id:9522601,\
   phase:2,\
   pass,\
   nolog,\
   skipAfter:END_WPHARD_IP_REPUTATION"
 
-SecRule TX:wphard.client_ip "@rx ^127\.0\.0\.1$" \
+SecRule TX:wphard.client_ip "@rx ^__never_match__$" \
   "id:9522602,\
   phase:2,\
   pass,\

--- a/plugins/wordpress-hardening-config.conf
+++ b/plugins/wordpress-hardening-config.conf
@@ -8,7 +8,7 @@
 # ------------------------------------------------------------------------
 
 # OWASP CRS Plugin
-# Plugin name: wordpress-hardering-plugin
+# Plugin name: wordpress-hardening-plugin
 # Plugin description: harden wordpress, minimize php/sql impact
 # Rule ID block base: 9,522,000-9,522,999
 # Plugin version: 1.0.0
@@ -72,14 +72,12 @@
 # Lock out an IP after X failed login attempts within a fixed 60-second window.
 # By default: enabled, 5 attempts per 60 seconds, whitelist: localhost + RFC 1918
 #
-# IMPORTANT — THE WINDOW IS FIXED AT 60 SECONDS:
-# ModSecurity's `expirevar` does not accept macro expansion for its TTL, so the
-# counter expiry in rule 9522411 is hardcoded to 60 seconds. The
-# tx.wphard.ratelimit_login_window variable therefore CANNOT change the real
-# window — it is retained only for the human-readable value printed in the
-# block log message (rule 9522412). Setting it has no effect on behaviour.
-# To change the actual window you must edit the literal
-# `expirevar:ip.login_attempts=60` in wordpress-hardening-before.conf.
+# WINDOW VALUES — choose one of: 30, 60, 120, 300, 600 (seconds).
+# expirevar does not accept macros, so the plugin dispatches on the configured
+# value through five literal expirevar rules (9522416-9522420). Any other value
+# silently falls back to 60s. The active window is logged in the 9522412 block
+# message and emitted as the wphard_retry_after env var (consumable by the
+# webserver to add a Retry-After response header).
 #
 # To override defaults, uncomment lines below and adjust values as needed.
 #
@@ -121,3 +119,15 @@
 #
 # Example: Enable IP reputation blocking
 #SecAction "id:9522053,phase:1,nolog,pass,t:none,setvar:'tx.wphard.ip_reputation_enabled=1'"
+
+# TRUSTED-PROXY PINNING FOR X-FORWARDED-FOR
+# By default the plugin honours X-Forwarded-For unconditionally (backward
+# compatible — works behind any single trusted proxy). To eliminate the
+# "deployed without a proxy" footgun where a direct attacker can spoof XFF,
+# enable this feature AND populate plugins/wordpress-hardening-trusted-proxies.data
+# with the CIDRs of your real upstream proxies. When enabled, XFF is honoured
+# ONLY when REMOTE_ADDR is in that list; otherwise the resolver falls back to
+# REMOTE_ADDR (the directly-connected peer).
+#
+# Example: Enable trusted-proxy pinning
+#SecAction "id:9522055,phase:1,nolog,pass,t:none,setvar:'tx.wphard.trusted_proxies_enabled=1'"

--- a/plugins/wordpress-hardening-login-countries.data
+++ b/plugins/wordpress-hardening-login-countries.data
@@ -3,8 +3,14 @@
 # Enable the feature with: setvar:tx.wphard.geoip_login_enabled=1
 # See plugins/wordpress-hardening-config.conf for configuration details.
 #
-# Example allowed countries:
-# NL
-# DE
-# GB
-# US
+# IMPORTANT: entries MUST be lowercase. Rules 9522500/9522501 apply
+# t:lowercase to the country header before storing it in TX, and the
+# allow-list lookup (9522508) uses @pmFromFile which is case-sensitive.
+# Adding "NL" (uppercase) here means NO country will ever be allow-listed
+# and every login attempt from a non-whitelisted IP will be blocked.
+#
+# Example allowed countries (lowercase, one per line):
+# nl
+# de
+# gb
+# us

--- a/plugins/wordpress-hardening-trusted-proxies.data
+++ b/plugins/wordpress-hardening-trusted-proxies.data
@@ -1,0 +1,14 @@
+# Trusted upstream proxies (CIDR notation, one per line).
+# Used by rule 9522064 (@ipMatchFromFile) to decide whether to honour
+# X-Forwarded-For. Only takes effect when tx.wphard.trusted_proxies_enabled=1.
+#
+# Populate with the real public-facing IPs of your CDN / load balancer / proxy:
+#
+# Cloudflare:        https://www.cloudflare.com/ips-v4 / https://www.cloudflare.com/ips-v6
+# AWS CloudFront:    https://d7uri8nf7uskq.cloudfront.net/tools/list-cloudfront-ips
+# Google Cloud LB:   https://www.gstatic.com/ipranges/cloud.json
+#
+# Example (uncomment + replace with your values):
+# 173.245.48.0/20
+# 103.21.244.0/22
+# 2400:cb00::/32


### PR DESCRIPTION
## Summary
Full audit of the two `.conf` files plus triage of `deb.error.log` on the production WAF. Eleven independent fixes (including one **critical** find on production), rule IDs preserved, all existing regression tests still pass.

### Critical: the plugin was silently disabled on production
Rule `9522099` (kill-switch) checked `TX:wordpress-hardening-plugin_enabled "@eq 0"` against a variable that was never set anywhere — and `@eq 0` against an unset var evaluates to true in ModSecurity. So the kill-switch fired on **every** request and removed the entire `9522000-9522999` rule range. Confirmed live on `deb.myguard.nl`:

- `grep -c 9522 /var/log/modsec_audit.log` returned `0` across 19 MB of recent traffic.
- `GET /wp-content/themes/myguard-deb/index.php` returned `500` (the `Call to undefined function get_header()` fatal seen in `deb.error.log`) instead of the expected `9522200` block.

Fix: new default-setter rule `9522098` sets the flag to `1` if unset (standard CRS plugin-template pattern). After deploying, modsec rule count went from **1296 → 1314**, the audit log now records `9522*` firings, and the theme-`index.php` probe now returns the configured deny status instead of a 500.

### Correctness
- **`9522109` admin-login case bypass** — chained inner rule had no transformations; `log=Admin` bypassed. Added `t:lowercase,t:trim`.
- **`9522061` XFF first-hop truncation** — regex had no terminator; `1.2.3.4junk` was silently accepted. Added `(?=$|[\s,])`.
- **`9522303` backup over-match** — `[-_]backup[-_]` matched legit slugs like `some-backup-plugin/style.css`. Now requires a backup-like extension.
- **`9522313` phpinfo substring** — would false-positive on any post slug containing "phpinfo". Anchored to path segment / arg-name.
- **`9522200` PHP allow-list too permissive** — `(?:.*/)?index.php$` allowed direct hits to any nested `index.php`. Tightened to root-only filenames + `/wp-admin/`. Combined with the critical kill-switch fix above, this is what eliminates the theme-`index.php` PHP fatals visible in `deb.error.log`.
- Plugin-name typo `hardering` → `hardening` in both headers.

### GeoIP feature was silently broken
Phase-1 lowercased the country header but the data file shipped uppercase examples (`NL`/`DE`/`GB`/`US`). `@pmFromFile` is case-sensitive — any operator who followed the docs would block **every** country. Data file now ships lowercase examples + an `IMPORTANT` note + README warning.

### Performance
- **`9522414` initcol** — persisted the IP collection to SDBM on every phase-2 request when rate-limiting was enabled. Now gated to `POST /wp-login.php` only.
- **Whitelist regex consolidation** — same RFC1918+loopback regex inlined at 6 sites. New phase-1 helper `9522063` sets `tx.wphard.client_is_private` once; all six sites now `@eq 1`. Stable rule IDs.

### RFC compliance
- **`9522412` returns 429** (RFC 6585 §4) instead of CRS-default 403. Exports `setenv:wphard_retry_after=<window>` so the webserver can emit a `Retry-After` header (README ships nginx/Angie + Apache snippets).

### Rate-limit window finally honoured
`expirevar` can't take a macro TTL, so the configured window was previously ignored (hardcoded 60s). New dispatcher rules `9522416`-`9522420` pick the literal `expirevar` for 30/60/120/300/600s.

### IPv6 support
- New `9522062` extracts IPv6 first-hop from XFF.
- `client_is_private` covers IPv6 `::1` and ULA `fc00::/7`, so all six whitelist sites now whitelist IPv6 private peers too.

### Trusted-proxy pinning (closes the "deployed without a proxy" footgun)
- New `tx.wphard.trusted_proxies_enabled` (default **OFF**, backward compatible).
- New `wordpress-hardening-trusted-proxies.data` (CIDR list).
- When enabled, XFF is honoured only if `REMOTE_ADDR` matches; else the resolver falls back to `REMOTE_ADDR`.

### Documentation
- README updated with: trusted-proxy pinning section, 429/Retry-After behaviour, lowercase GeoIP allow-list requirement, IPv6-aware whitelisting, the 30/60/120/300/600 window buckets, a rule-ID map of the allocated range, and an honest note that **persistent-collection rate-limiting is Apache-only** in practice (libmodsecurity3 has gaps — use the webserver's native `limit_req` on nginx/Angie).
- INSTALL lists all five `.data` files.

## Test plan
- [x] `bash scripts/ci-local.sh` — all checks pass (pmFromFile targets resolve, rule IDs unique and in range, secrules-parsing OK, no chained-skipAfter, markers reachable, regression YAML valid)
- [x] **CI integration suite — `go-ftw run`: 130/130 tests pass on both backends locally** (Angie + libmodsecurity3 v3 *and* Apache + mod_security2)
- [x] **Post-deploy on `deb.myguard.nl`**: theme-`index.php` no longer triggers `get_header()` fatal — `9522200` now appears in the modsec audit log and the request returns the configured deny status. Modsec rule count went from `1296 → 1314` confirming the plugin actually loaded for the first time.
- [x] **Rate-limit 429**: verified on the Apache CI backend (FTW test `9522412-1` passes). On the production Angie/libmodsec3 backend the rule loads but the `IP:` collection never persists — flagged as a documented engine limitation rather than a plugin defect.
