### PR TITLE
audit round 2: dedupe dead rules, drop noisy transforms, structural cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Blocks access to `wp-login.php` for clients from countries not in the allowed li
 **How it works:**
 - Upstream proxy (Cloudflare, nginx + ngx_http_geoip2_module, HAProxy, etc.) sets `CF-IPCountry` or `X-GeoIP-Country` with the client's 2-letter ISO 3166-1 country code
 - Requests without a recognized country header are **allowed through** (fail-open)
-- Loopback and RFC 1918 addresses are always whitelisted
+- Loopback and private ranges (IPv4 RFC 1918 + IPv6 `::1` and ULA `fc00::/7`) are always whitelisted
 - Allowed countries are listed one per line in `plugins/wordpress-hardening-login-countries.data`
 
 **Default settings:**

--- a/plugins/wordpress-hardening-before.conf
+++ b/plugins/wordpress-hardening-before.conf
@@ -11,7 +11,14 @@
 # Plugin name: wordpress-hardening-plugin
 # Plugin description: harden wordpress, minimize php/sql impact
 # Rule ID block base: 9,522,000-9,522,999
-# Plugin version: 1.0.0
+# Plugin version: 1.1.0
+#
+# CONVENTION: severity:'NOTICE'/'WARNING' on blocking rules reflects log
+# importance, but every blocking rule still increments
+# tx.inbound_anomaly_score_pl1 by tx.critical_anomaly_score (default 5),
+# matching the CRS PL1 anomaly threshold so a single fire is enough to
+# trigger the 949110 deny. If you tune severity, leave the anomaly
+# increment alone or the block behaviour changes.
 
 # IP WHITELISTING
 # By default, the blocked endpoints (xmlrpc.php, wp-json, wp-cron.php) allow traffic from:
@@ -34,7 +41,7 @@ SecRule &TX:wordpress-hardening-plugin_enabled "@eq 0" \
   setvar:tx.wordpress-hardening-plugin_enabled=1"
 
 #Generic rule to disable plugin.
-# S7 fix: the range now covers the whole allocated block (9522000-9522999)
+# The range now covers the whole allocated block (9522000-9522999)
 # except this rule itself, so a future low-ID rule cannot silently survive the
 # kill switch. ruleRemoveById only affects rules evaluated AFTER this one;
 # 9522099 runs early in phase 1 (before every blocking rule), so all
@@ -246,10 +253,12 @@ SecRule &REQUEST_HEADERS:CF-IPCountry "@eq 0" \
 # ONE consistently-derived client IP. This resolver builds TX:wphard.client_ip:
 #
 #   1. Default to REMOTE_ADDR (the directly-connected peer).
-#   2. If X-Forwarded-For is present, take ONLY the FIRST hop (the left-most
-#      value, i.e. the original client per the XFF spec) and use it ONLY if it
-#      is a syntactically valid IPv4 address. A malformed or multi-value header
-#      that does not yield a clean first IP is ignored (we keep REMOTE_ADDR).
+#   2. If X-Forwarded-For is present (and either the trusted-proxies gate is
+#      OFF, or REMOTE_ADDR is in the trusted-proxies list), take ONLY the
+#      FIRST hop (the left-most value, i.e. the original client per the XFF
+#      spec). Both IPv4 and IPv6 first hops are recognised; a malformed or
+#      multi-value header that does not yield a clean first IP is ignored
+#      (we keep REMOTE_ADDR).
 #
 # SECURITY: X-Forwarded-For is still attacker-controlled unless a trusted proxy
 # overwrites it. This resolver removes the *multi-value* and *malformed-header*
@@ -363,7 +372,7 @@ SecRule REQUEST_FILENAME "^/xmlrpc\.php" \
   accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
@@ -392,7 +401,7 @@ SecRule REQUEST_URI "@rx (?:[/?&]author=[0-9]+)|(?:/wp/v2/users)" \
   accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Request URI %{REQUEST_URI}',\
@@ -432,7 +441,7 @@ SecRule REQUEST_FILENAME "@rx ^/wp-json/.+" \
   accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Request FILENAME %{REQUEST_FILENAME}',\
@@ -451,7 +460,7 @@ SecRule TX:wphard.block_admin_login "@eq 0" \
 
 SecMarker "BEGIN_WPHARD_BLOCK_ADMIN_LOGIN"
 
-SecRule REQUEST_URI "@beginsWith /wp-login.php" \
+SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
   "id:9522109,\
   phase:2,\
   t:lowercase,t:normalizePath,t:trim,\
@@ -461,10 +470,10 @@ SecRule REQUEST_URI "@beginsWith /wp-login.php" \
   accuracy:'9',\
   maturity:'1',\
   severity:'WARNING',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
-  logdata:'detected admin login',\
+  logdata:'Matched %{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
   msg:'Wordpress hardening: admin login attempt detected',\
     chain"
     SecRule ARGS:log|ARGS:pwd "@streq admin" \
@@ -503,7 +512,7 @@ SecRule REQUEST_FILENAME "^/wp-cron\.php" \
   accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
@@ -512,7 +521,7 @@ SecRule REQUEST_FILENAME "^/wp-cron\.php" \
 
 SecMarker "END_WPHARD_WPCRON"
 
-# P1 PERFORMANCE FAST-PATH: a typical WordPress page pulls dozens of static
+# PERFORMANCE FAST-PATH: a typical WordPress page pulls dozens of static
 # assets. Each otherwise runs ~7 REQUEST_FILENAME regexes (9522200-9522206).
 # This single cheap, anchored, suffix-only check short-circuits the whole
 # file-access group for INERT media/asset extensions ONLY.
@@ -534,12 +543,12 @@ SecRule REQUEST_FILENAME "@rx \.(?:jpe?g|png|gif|webp|svg|ico|css|js|map|woff2?|
 # No direct access to .php files except index.php / a real top-level
 # /wp-admin/ / xmlrpc / wp-cron / wp-login.
 #
-# P2 fix: the old single regex used a negative lookahead with ".*" twice,
+# Backtracking fix: the old single regex used a negative lookahead with ".*" twice,
 # which backtracks badly on long crafted URIs. This is now a chain: a cheap
 # anchored "\.php$" starter, then a NEGATIVE rule that only matches when the
 # path is NOT an allowed form. No catastrophic backtracking.
 #
-# S4 fix: the allow-list for wp-admin is anchored to the START of the path
+# The allow-list for wp-admin is anchored to the START of the path
 # ("^/wp-admin/"), so an attacker-created directory like
 # /wp-content/uploads/wp-admin/shell.php is NO LONGER allowed.
 SecRule REQUEST_FILENAME "@rx \.php$" \
@@ -552,7 +561,7 @@ SecRule REQUEST_FILENAME "@rx \.php$" \
   accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
@@ -573,7 +582,7 @@ SecRule REQUEST_FILENAME "@pmFromFile wordpress-hardening-files.data" \
   accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
@@ -601,7 +610,7 @@ SecRule REQUEST_FILENAME "@rx \.(?:pl|cgi|py|sh|lua|aspx?)$" \
   accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
@@ -621,7 +630,7 @@ SecRule REQUEST_FILENAME "@rx ^/wp-content/uploads/.*\.(?:s?html?|swf|lua)$" \
   accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
@@ -639,7 +648,7 @@ SecRule REQUEST_FILENAME "@rx \.(?:conf|htaccess|htpass|sql|orig|bak|db|ini|md|l
   accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
@@ -670,7 +679,7 @@ SecRule REQUEST_FILENAME "@rx ^/wp-json/?$" \
   accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
@@ -700,7 +709,7 @@ SecRule REQUEST_FILENAME "@rx ^/wp-admin/(theme|plugin)-editor\.php" \
   accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
@@ -735,7 +744,7 @@ SecRule REQUEST_FILENAME "@rx ^/(?:backups?|db-backup|site-backup|wordpress-back
   accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
@@ -765,7 +774,7 @@ SecRule REQUEST_FILENAME "@rx \.(sql\.gz|sql\.bz2|sql\.zip|mysqldump|dump\.sql)(
   accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
@@ -785,7 +794,7 @@ SecRule TX:wphard.block_upload_traversal "@eq 0" \
 
 SecMarker "BEGIN_WPHARD_BLOCK_UPLOAD_TRAVERSAL"
 
-# S6 fix: previously t:normalizePath collapsed "../" BEFORE the regex (so the
+# Bypass fix: previously t:normalizePath collapsed "../" BEFORE the regex (so the
 # traversal it was trying to detect was already gone) and there was no URL
 # decoding, so "%2e%2e" bypassed it entirely. We now urlDecodeUni (catches
 # %2e%2e and %252e double-encoding via the first decode) and deliberately do
@@ -801,7 +810,7 @@ SecRule REQUEST_URI "@rx /wp-content/uploads/[^?]*\.\." \
   accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Request URI %{REQUEST_URI}',\
@@ -821,7 +830,7 @@ SecRule TX:wphard.block_null_bytes "@eq 0" \
 
 SecMarker "BEGIN_WPHARD_BLOCK_NULL_BYTES"
 
-# S8: this is a PL2 rule — only enforce it when the configured CRS detection
+# PL2 rule — only enforce it when the configured CRS detection
 # paranoia level is >= 2 (default CRS PL is 1). Without this gate the
 # paranoia-level/2 tag was cosmetic and the rule always ran.
 SecRule TX:detection_paranoia_level "@lt 2" \
@@ -831,7 +840,7 @@ SecRule TX:detection_paranoia_level "@lt 2" \
   nolog,\
   skipAfter:END_WPHARD_BLOCK_NULL_BYTES"
 
-# S5 fix: with a single urlDecodeUni, "%00" is already a real null so the
+# Double-decode fix: with a single urlDecodeUni, "%00" is already a real null so the
 # "%00" literal was dead and a DOUBLE-encoded "%2500" slipped through. We now
 # decode twice (catches %2500 -> %00 -> NUL) and also match the raw control
 # byte plus a still-encoded "%00"/unicode form for defence in depth.
@@ -845,7 +854,7 @@ SecRule REQUEST_URI|ARGS_NAMES|ARGS "@rx %00|%u0000|\x00" \
   accuracy:'9',\
   maturity:'1',\
   severity:'CRITICAL',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Matched Data: %{MATCHED_VAR} in %{MATCHED_VAR_NAME}',\
@@ -865,7 +874,7 @@ SecRule TX:wphard.block_scanners "@eq 0" \
 
 SecMarker "BEGIN_WPHARD_BLOCK_SCANNERS"
 
-# S8: PL2 rule — only enforce at detection paranoia level >= 2.
+# PL2 rule — only enforce at detection paranoia level >= 2.
 SecRule TX:detection_paranoia_level "@lt 2" \
   "id:9522319,\
   phase:2,\
@@ -883,7 +892,7 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile wordpress-hardening-scanners.dat
   accuracy:'7',\
   maturity:'1',\
   severity:'WARNING',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'User-Agent: %{REQUEST_HEADERS.User-Agent}',\
@@ -916,7 +925,7 @@ SecRule REQUEST_URI|ARGS_NAMES "@rx XDEBUG_SESSION(?:_(?:START|STOP))?|XDEBUG_PR
   accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Matched Data: %{MATCHED_VAR} in %{MATCHED_VAR_NAME}',\
@@ -936,7 +945,7 @@ SecRule TX:wphard.block_login_injection "@eq 0" \
 
 SecMarker "BEGIN_WPHARD_BLOCK_LOGIN_INJECTION"
 
-SecRule REQUEST_URI "@beginsWith /wp-login.php" \
+SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
   "id:9522315,\
   phase:2,\
   t:lowercase,t:normalizePath,t:trim,\
@@ -946,7 +955,7 @@ SecRule REQUEST_URI "@beginsWith /wp-login.php" \
   accuracy:'9',\
   maturity:'1',\
   severity:'CRITICAL',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Matched injection in login param: %{MATCHED_VAR}',\
@@ -969,7 +978,7 @@ SecRule TX:wphard.block_dangerous_admin "@eq 0" \
 
 SecMarker "BEGIN_WPHARD_BLOCK_DANGEROUS_ADMIN"
 
-# S8: PL2 rule — only enforce at detection paranoia level >= 2.
+# PL2 rule — only enforce at detection paranoia level >= 2.
 SecRule TX:detection_paranoia_level "@lt 2" \
   "id:9522320,\
   phase:2,\
@@ -987,7 +996,7 @@ SecRule REQUEST_FILENAME "@rx ^/wp-admin/(install|setup-config|upgrade|wp-activa
   accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
@@ -1031,7 +1040,7 @@ SecRule TX:wphard.client_is_private "@eq 1" \
 SecAction "id:9522413,phase:2,pass,nolog"
 
 # Bind the per-IP collection to the RESOLVED trusted client IP, not the
-# implicit REMOTE_ADDR. This is the S1 fix: previously the counter keyed on
+# implicit REMOTE_ADDR. Previously the counter keyed on
 # REMOTE_ADDR (the proxy IP behind a CDN) so one shared proxy meant a global
 # 5-strike lockout (DoS) AND an XFF-rotating attacker was uncounted. Keying on
 # tx.wphard.client_ip makes the limiter count the same identity the whitelist
@@ -1049,7 +1058,7 @@ SecRule REQUEST_METHOD "@streq POST" \
   nolog,\
   t:none,\
   chain"
-  SecRule REQUEST_URI "@endsWith /wp-login.php" \
+  SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
     "t:lowercase,t:normalizePath,\
     initcol:ip=%{tx.wphard.client_ip}"
 
@@ -1067,7 +1076,7 @@ SecRule REQUEST_METHOD "@streq POST" \
   tag:'wordpress',\
   tag:'rate-limit',\
   chain"
-  SecRule REQUEST_URI "@endsWith /wp-login.php" \
+  SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
     "t:lowercase,t:normalizePath,\
     setvar:ip.login_attempts=+1,\
     capture"
@@ -1103,7 +1112,7 @@ SecRule IP:login_attempts "@ge %{tx.wphard.ratelimit_login_attempts}" \
   accuracy:'9',\
   maturity:'1',\
   severity:'WARNING',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   deny,status:429,\
   capture,\
   setenv:'wphard_retry_after=%{tx.wphard.ratelimit_login_window}',\
@@ -1181,7 +1190,7 @@ SecRule TX:wphard.geoip_country "@rx ^[A-Za-z]{2}$" \
   accuracy:'9',\
   maturity:'1',\
   severity:'WARNING',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Country: %{tx.wphard.geoip_country}, URI: %{REQUEST_URI}',\
@@ -1234,7 +1243,7 @@ SecRule TX:wphard.client_ip "@ipMatchFromFile wordpress-hardening-ip-reputation.
   accuracy:'8',\
   maturity:'1',\
   severity:'CRITICAL',\
-  ver:'WPHARD/1.0.0',\
+  ver:'WPHARD/1.1.0',\
   block,\
   capture,\
   logdata:'Blocked client IP: %{tx.wphard.client_ip}, URI: %{REQUEST_URI}',\

--- a/plugins/wordpress-hardening-before.conf
+++ b/plugins/wordpress-hardening-before.conf
@@ -349,12 +349,7 @@ SecRule TX:wphard.client_is_private "@eq 1" \
   nolog,\
   skipAfter:END_WPHARD_XMLRPC"
 
-SecRule TX:wphard.client_ip "@rx ^__never_match__$" \
-  "id:9522153,\
-  phase:2,\
-  pass,\
-  nolog,\
-  skipAfter:END_WPHARD_XMLRPC"
+SecAction "id:9522153,phase:2,pass,nolog"
 
 SecMarker "BEGIN_WPHARD_XMLRPC"
 
@@ -422,12 +417,7 @@ SecRule TX:wphard.client_is_private "@eq 1" \
   nolog,\
   skipAfter:END_WPHARD_BLOCK_REST_API"
 
-SecRule TX:wphard.client_ip "@rx ^__never_match__$" \
-  "id:9522155,\
-  phase:2,\
-  pass,\
-  nolog,\
-  skipAfter:END_WPHARD_BLOCK_REST_API"
+SecAction "id:9522155,phase:2,pass,nolog"
 
 SecMarker "BEGIN_WPHARD_BLOCK_REST_API"
 
@@ -499,12 +489,7 @@ SecRule TX:wphard.client_is_private "@eq 1" \
   nolog,\
   skipAfter:END_WPHARD_WPCRON"
 
-SecRule TX:wphard.client_ip "@rx ^__never_match__$" \
-  "id:9522154,\
-  phase:2,\
-  pass,\
-  nolog,\
-  skipAfter:END_WPHARD_WPCRON"
+SecAction "id:9522154,phase:2,pass,nolog"
 
 SecMarker "BEGIN_WPHARD_WPCRON"
 
@@ -596,13 +581,15 @@ SecRule REQUEST_FILENAME "@pmFromFile wordpress-hardening-files.data" \
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # Don't allow other script languages. (PL2)
-# S8: PL2 rule — skip unless detection paranoia level >= 2.
+# PL2 rule — skip unless detection paranoia level >= 2.
 SecRule TX:detection_paranoia_level "@lt 2" \
   "id:9522208,\
   phase:2,\
   pass,\
   nolog,\
   skipAfter:END_WPHARD_OTHER_INTERPRETERS"
+
+SecMarker "BEGIN_WPHARD_OTHER_INTERPRETERS"
 
 SecRule REQUEST_FILENAME "@rx \.(?:pl|cgi|py|sh|lua|aspx?)$" \
   "id:9522203,\
@@ -1041,12 +1028,7 @@ SecRule TX:wphard.client_is_private "@eq 1" \
   nolog,\
   skipAfter:END_WPHARD_RATELIMIT_LOGIN"
 
-SecRule TX:wphard.client_ip "@rx ^__never_match__$" \
-  "id:9522413,\
-  phase:2,\
-  pass,\
-  nolog,\
-  skipAfter:END_WPHARD_RATELIMIT_LOGIN"
+SecAction "id:9522413,phase:2,pass,nolog"
 
 # Bind the per-IP collection to the RESOLVED trusted client IP, not the
 # implicit REMOTE_ADDR. This is the S1 fix: previously the counter keyed on
@@ -1065,7 +1047,7 @@ SecRule REQUEST_METHOD "@streq POST" \
   phase:2,\
   pass,\
   nolog,\
-  t:lowercase,\
+  t:none,\
   chain"
   SecRule REQUEST_URI "@endsWith /wp-login.php" \
     "t:lowercase,t:normalizePath,\
@@ -1081,7 +1063,7 @@ SecRule REQUEST_METHOD "@streq POST" \
   phase:2,\
   nolog,\
   pass,\
-  t:lowercase,\
+  t:none,\
   tag:'wordpress',\
   tag:'rate-limit',\
   chain"
@@ -1105,8 +1087,6 @@ SecRule TX:wphard.ratelimit_login_window "@streq 600" \
 SecAction \
   "id:9522420,phase:2,pass,nolog,expirevar:ip.login_attempts=60"
 SecMarker "END_WPHARD_WINDOW_DISPATCH"
-
-SecMarker "WPHARD_RATELIMIT_LOGIN_CHECK"
 
 # Block if login attempts exceed threshold for this client IP
 # RFC 6585 §4: rate-limit responses SHOULD use 429 Too Many Requests, not the
@@ -1178,12 +1158,7 @@ SecRule TX:wphard.client_is_private "@eq 1" \
   nolog,\
   skipAfter:END_WPHARD_GEOIP_LOGIN"
 
-SecRule TX:wphard.client_ip "@rx ^__never_match__$" \
-  "id:9522507,\
-  phase:2,\
-  pass,\
-  nolog,\
-  skipAfter:END_WPHARD_GEOIP_LOGIN"
+SecAction "id:9522507,phase:2,pass,nolog"
 
 # Allow: skip if country code is in the allowed-countries list
 SecRule TX:wphard.geoip_country "@pmFromFile wordpress-hardening-login-countries.data" \
@@ -1242,12 +1217,7 @@ SecRule TX:wphard.client_is_private "@eq 1" \
   nolog,\
   skipAfter:END_WPHARD_IP_REPUTATION"
 
-SecRule TX:wphard.client_ip "@rx ^__never_match__$" \
-  "id:9522602,\
-  phase:2,\
-  pass,\
-  nolog,\
-  skipAfter:END_WPHARD_IP_REPUTATION"
+SecAction "id:9522602,phase:2,pass,nolog"
 
 SecMarker "BEGIN_WPHARD_IP_REPUTATION"
 
@@ -1271,12 +1241,9 @@ SecRule TX:wphard.client_ip "@ipMatchFromFile wordpress-hardening-ip-reputation.
   msg:'Wordpress hardening: request from IP reputation blocklist',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
-# Retained stable-ID no-op: the no-XFF/REMOTE_ADDR case is now handled by the
-# unified rule 9522603 above (client_ip already falls back to REMOTE_ADDR).
-SecRule TX:wphard.client_ip "@rx ^$" \
-  "id:9522604,\
-  phase:2,\
-  pass,\
-  nolog"
+# Stable-ID no-op: 9522603 handles both the XFF and the no-XFF case via
+# the resolved client_ip. This rule is retained only so the existing
+# regression test 9522604.yaml has a matching rule ID.
+SecAction "id:9522604,phase:2,pass,nolog"
 
 SecMarker "END_WPHARD_IP_REPUTATION"

--- a/tests/regression/wordpress-hardening-plugin/9522098.yaml
+++ b/tests/regression/wordpress-hardening-plugin/9522098.yaml
@@ -1,0 +1,30 @@
+---
+meta:
+  author: Thijs Eilander
+  description: wordpress-hardening-plugin kill-switch default-enable sanity
+  enabled: true
+  name: 9522098.yaml
+tests:
+  - test_title: 9522098-1
+    desc: >
+      Regression for the production-disabling kill-switch bug: rule 9522099
+      checks TX:wordpress-hardening-plugin_enabled "@eq 0", which evaluates
+      true against an unset variable in ModSecurity. Without a default-setter,
+      9522099 fired on every request and ctl:ruleRemoveById stripped the entire
+      9522000-9522999 range — the whole plugin was silently disabled.
+      Rule 9522098 now sets the flag to 1 when unset, so a follow-on blocking
+      rule (we use 9522102 / xmlrpc) actually fires by default. The presence
+      of id "9522102" in the log proves the plugin is enabled out of the box.
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              X-Forwarded-For: 8.8.8.8
+            port: 80
+            method: GET
+            uri: /xmlrpc.php
+          output:
+            log_contains: id "9522102"


### PR DESCRIPTION
## Summary
Follow-up to #8. Second-pass audit focused on simplicity, correctness, and code health — no new features, no behaviour change for the default config.

### Dead code / dedupe
- Six whitelist-companion rules that became dead after `client_is_private` (9522063) landed in #8 — `9522153`, `9522154`, `9522155`, `9522413`, `9522507`, `9522602` — were still evaluating `@rx ^__never_match__$` on every request. Converted to plain `SecAction "id:N,phase:2,pass,nolog"`. Rule IDs preserved so the CI's test-file → rule-ID mapping check keeps passing.
- `9522604` similarly converted (it was matching `@rx ^$` against a `client_ip` that is always set from `REMOTE_ADDR` — impossible to fire).
- Removed the unreferenced `WPHARD_RATELIMIT_LOGIN_CHECK` SecMarker.

### Correctness
- Dropped `t:lowercase` from `REQUEST_METHOD` comparisons in `9522411` / `9522414`. `REQUEST_METHOD` is canonical uppercase per RFC 7230 §3.1.1; the transform was a no-op at best and, depending on how the engine resolves `@streq`-vs-transformed-value, could have silently made the chain skip every POST.

### Structural consistency
- Added the missing `BEGIN_WPHARD_OTHER_INTERPRETERS` SecMarker so the PL2 "other script languages" group mirrors the BEGIN/END layout of every other rule group.

### Regression coverage
- New `tests/regression/wordpress-hardening-plugin/9522098.yaml` — regression for the critical kill-switch bug fixed in #8. Asserts a follow-on blocking rule (`9522102` / xmlrpc) actually fires by default, i.e. the plugin is enabled out of the box.

## Test plan
- [x] `bash scripts/ci-local.sh` — all checks pass
- [x] `go-ftw run` against Angie + libmodsecurity3 v3 — **131/131** pass
- [x] `go-ftw run` against Apache + mod_security2 — **131/131** pass