### PR TITLE
fix(9522104): exempt /wp/v2/users/me and honor private-IP whitelist

### DIFF
--- a/plugins/wordpress-hardening-before.conf
+++ b/plugins/wordpress-hardening-before.conf
@@ -389,9 +389,22 @@ SecRule TX:wphard.block_user_enumeration "@eq 0" \
   nolog,\
   skipAfter:END_WPHARD_USER_ENUMERATION"
 
+# Skip user-enumeration check if client is on a trusted private network
+# (mirrors xmlrpc/rest-api/wpcron whitelist behavior — 9522150/9522151/9522152).
+SecRule TX:wphard.client_is_private "@eq 1" \
+  "id:9522156,\
+  phase:2,\
+  pass,\
+  nolog,\
+  skipAfter:END_WPHARD_USER_ENUMERATION"
+
 SecMarker "BEGIN_WPHARD_USER_ENUMERATION"
 
-SecRule REQUEST_URI "@rx (?:[/?&]author=[0-9]+)|(?:/wp/v2/users)" \
+# Match author enumeration (?author=<n>), the bare /wp/v2/users collection,
+# and numeric-ID lookups (/wp/v2/users/<n>). /wp/v2/users/me and other
+# non-numeric subroutes pass through — /me returns only the authenticated
+# user, used by the WP block editor and admin UI, so it's not enumeration.
+SecRule REQUEST_URI "@rx (?:[/?&]author=[0-9]+)|(?:/wp/v2/users/?(?:\?|$))|(?:/wp/v2/users/[0-9]+)" \
   "id:9522104,\
   phase:2,\
   t:lowercase,t:normalizePath,t:trim,t:urlDecodeUni,\
@@ -409,6 +422,7 @@ SecRule REQUEST_URI "@rx (?:[/?&]author=[0-9]+)|(?:/wp/v2/users)" \
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 SecMarker "END_WPHARD_USER_ENUMERATION"
+# ID inventory: 9522156 added 2026-05-21 for user-enum private-IP whitelist.
 
 # Check if restapi should be blocked and if not, skip
 SecRule TX:wphard.block_rest_api "@eq 0" \

--- a/tests/regression/wordpress-hardening-plugin/9522104.yaml
+++ b/tests/regression/wordpress-hardening-plugin/9522104.yaml
@@ -57,7 +57,7 @@ tests:
           output:
             log_contains: id "9522104"
   - test_title: 9522104-4
-    desc: Test if user enumeration is blocked
+    desc: Test if a numeric user-ID lookup is blocked (/wp/v2/users/<n>)
     stages:
       - stage:
           input:
@@ -68,7 +68,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: GET
-            uri: /wp-json/wp/v2/USERS=99999999999999999999999
+            uri: /wp-json/wp/v2/users/42
             data: |
               text
           output:
@@ -184,3 +184,32 @@ tests:
             uri: /?author=42
           output:
             log_contains: id "9522104"
+  - test_title: 9522104-12
+    desc: >
+      Regression: /wp-json/wp/v2/users/me returns ONLY the authenticated
+      user, not a collection. It's used by the WP block editor and the
+      admin UI on every page load. It must not be flagged as enumeration.
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-json/wp/v2/users/me
+          output:
+            no_log_contains: id "9522104"
+  - test_title: 9522104-13
+    desc: >
+      Regression: /users/me with the editor's typical context+locale query
+      args (the exact request the block editor issues) must also pass.
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-json/wp/v2/users/me?context=edit&_locale=user
+          output:
+            no_log_contains: id "9522104"


### PR DESCRIPTION
## Summary

- Rule **9522104** ("user enumeration detected") was matching any path containing `/wp/v2/users`, including `/wp-json/wp/v2/users/me` — the WordPress current-user endpoint hit on every block-editor and admin page load. Caught in production on a real site, blocking legitimate admin sessions.
- Narrowed the regex so only true enumeration paths trigger: bare `/wp/v2/users` collection (with optional trailing `/` or `?query`) and numeric-ID lookups `/wp/v2/users/<n>`. `/users/me` and other non-numeric subroutes pass through.
- Added rule **9522156** to honor the `tx.wphard.client_is_private` whitelist for the user-enum check, mirroring the pattern already used by xmlrpc (9522150), rest-api (9522151), and wpcron (9522152). Without this, internal monitoring and loopback admin tooling get blocked while the neighbouring rules deliberately exempt them.

## Why `/users/me` is not enumeration

`/wp/v2/users/me` is a WordPress REST shortcut that returns **only the currently authenticated user**. It does not list users, does not accept an ID, and requires a valid auth cookie/nonce. The block editor calls it as `/wp-json/wp/v2/users/me?context=edit&_locale=user` on load; blocking it breaks the editor entirely.

## Test plan

- [x] Regex sanity-checked offline against all existing and new test URIs (all expected outcomes hold).
- [x] Retargeted `9522104-4` from a synthetic `/USERS=…` bypass to a realistic numeric-ID lookup that the tightened regex must still block.
- [x] Added `9522104-12` and `9522104-13` as negative tests pinning `/users/me` (with and without the editor's typical `context=edit&_locale=user` query string).
- [x] Existing positive tests `9522104-1/2/3/5/6/7/8/11` (author=N variants, bare collection, `?rest_route=`) all still match.
- [x] Existing negative tests `9522104-9/10` (`coauthor=5`, `/our-authors-page`) still pass.
- [x] Local pre-push hooks (regression YAML validation) pass.
- [x] CI integration run on this branch.