### PR TITLE
Audit round 4: rule additions, ID collision fixes, regression tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ What this plugin does so far:
 - Automatic IP reputation blocklist blocking all requests from listed IPs/CIDRs (configurable, default: disabled) (PL1)
 - Trusted-proxy pinning for X-Forwarded-For (configurable, default: disabled — backward compatible) (PL1)
 - IPv6-aware client-IP resolution and private-network whitelisting (loopback + RFC 1918 + IPv6 `::1` + ULA `fc00::/7`)
-- Strip version-disclosure response headers — X-Pingback, X-Powered-By, REST Link rel=api.w.org (configurable, default: block) (PL1)
+- Detect version-disclosure response headers — X-Pingback, X-Powered-By, REST Link rel=api.w.org. Real stripping must be at the proxy: `proxy_hide_header X-Pingback; proxy_hide_header X-Powered-By; more_clear_headers "Link";` (configurable, default: tag) (PL1)
 - Hard-block info-leak paths in phase:1 — readme.html, license.txt, .user.ini, wp-admin/install.php, wp-admin/setup-config.php, wp-includes/wlwmanifest.xml, wp-content/debug.log (configurable, default: block) (PL1)
 - Block CVE-2018-6389 DoS — long `?load=` on wp-admin/load-scripts.php and load-styles.php (configurable, default: block) (PL1)
 - Block VCS / dotfile probes — .env, .git/, .svn/, .hg/, .bzr/, .htpasswd, .DS_Store (configurable, default: block) (PL1)
@@ -45,7 +45,7 @@ What this plugin does so far:
 - Block known-CVE plugin signatures — SureTriggers/OttoKit (CVE-2025-3102, CVE-2025-27007), Bricks Builder (CVE-2024-25600) (configurable, default: block) (PL1)
 - Block uncommon HTTP methods on /wp-admin/, /wp-login.php, /xmlrpc.php, /wp-cron.php — TRACE/TRACK/DEBUG/PROPFIND/MKCOL/COPY/MOVE/LOCK/UNLOCK/PUT/DELETE/PATCH (configurable, default: block) (PL1)
 - Block legacy CVE scanner probes — revslider, timthumb, WP Symposium, MailPoet wysija_captcha, wp-file-manager, Duplicator installer (configurable, default: block) (PL1)
-- BREACH/CRIME compression side-channel mitigation — strip Accept-Encoding on /wp-admin/, /wp-login.php, /wp-json/* so secret-bearing responses serve uncompressed (configurable, default: block) (PL1)
+- BREACH/CRIME compression side-channel detection — tag requests to /wp-admin/, /wp-login.php, /wp-json/* (configurable, default: tag). Real stripping must be configured at the proxy: `proxy_set_header Accept-Encoding "";` + `gzip off;` + `brotli off;` on those locations. (PL1)
 - Block public /author/<slug>/ archive pages (configurable, default: non-block — most blogs expose these) (PL2)
 
 ## IP Whitelisting

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ What this plugin does so far:
 - Block compressed database dump access (.sql.gz/.sql.bz2/.sql.zip) (configurable, default: block) (PL1)
 - Block directory traversal attempts in /wp-content/uploads/ (configurable, default: block) (PL1)
 - Block null byte injection in URIs and parameters (configurable, default: block) (PL2)
-- Block known security scanner user agents like nikto, sqlmap, wpscan (configurable, default: non-block) (PL2)
+- Block known security scanner user agents like nikto, sqlmap, wpscan (configurable, default: non-block) (PL2). **SEO note:** the bundled UA list also includes third-party SEO crawlers (Ahrefs, Semrush, Majestic/MJ12, Moz/dotbot/rogerbot, Petal, etc.). Enabling this toggle hides your site from those services. Search-engine bots (Googlebot, Bingbot) and social previews (Twitterbot, LinkedInBot, facebookexternalhit/1.1) are NOT in the list and continue to work.
 - Block XDebug and phpinfo debug probe parameters (configurable, default: block) (PL1)
 - Block code injection patterns in wp-login.php POST parameters (configurable, default: block) (PL1)
 - Block dangerous wp-admin endpoints — upgrade.php, wp-activate.php (configurable, default: block) (PL2)
@@ -81,6 +81,8 @@ To eliminate that footgun:
    ```
 
 When enabled, `X-Forwarded-For` is honoured **only** if `REMOTE_ADDR` is in that list; otherwise the resolver falls back to `REMOTE_ADDR`.
+
+> **Scope:** the private-IP whitelist only applies to the xmlrpc / wp-json / wp-cron rules (`9522102`, `9522107`, `9522111`, `9522207`). The user-enumeration rule (`9522104`), the direct-PHP-access rule (`9522200`), sensitive-files (`9522202`/`9522206`), info-leak (`9522100`), VCS-dotfile (`9522113`), and the audit-round-4 protections (`9522112`-`9522122`, `9522701`-`9522703`) apply to **all** clients regardless of source IP — they are flagging request shapes that no legitimate caller (internal or external) produces.
 
 ## Configuration
 
@@ -248,6 +250,16 @@ Please see https://coreruleset.org/docs/concepts/plugins/#how-to-install-a-plugi
 
 ## Disabling the plugin
 The plugin can be disabled by uncommenting rule 9522010 inside ``plugins/wordpress-config.conf`` or by removing the includes for this plugin.
+
+## Known false-positive patterns
+
+Production traffic on `deb.myguard.nl` was audited on 2026-05-22; only the cases below have ever fired the hardening rules on legitimate requests. Everything else (138× `9522202`, 66× `9522206`, 24× `9522200`, 3× `9522104` over the recent window) was confirmed scanner / probe traffic.
+
+| Rule | Trigger | Why it's a FP | Mitigation |
+| ---- | ------- | ------------- | ---------- |
+| `9522104` | `GET /wp-json/wp/v2/users/me` (with or without `?context=edit&_locale=user`) | The block editor and `/wp-admin/` UI call `/users/me` on every page load to get the current user. It returns ONLY the authenticated user — it's not enumeration. | Tighten the regex to `(?:[/?&]author=[0-9]+)\|(?:/wp/v2/users/?(?:\?\|$))\|(?:/wp/v2/users/[0-9]+)` so `/users/me` and other non-numeric subroutes pass through. Numeric-ID lookups (`/users/42`) and the bare collection still block. |
+| `9522104` | Internal / loopback admin tooling | The xmlrpc / rest-api / wpcron rules already skip private-IP clients (`tx.wphard.client_is_private`); `9522104` does not. | Mirror the existing skip pattern (`SecRule TX:wphard.client_is_private "@eq 1" ... skipAfter:END_WPHARD_USER_ENUMERATION`) before `BEGIN_WPHARD_USER_ENUMERATION`. |
+| CRS `950140` (not this plugin, but commonly co-deployed) | Outbound block of blog posts containing `#!/...` shell snippets | CRS treats shebangs in the response body as "CGI source code leakage". Tutorial blogs that publish shell commands hit this on every post view. | Disable `950140` for the affected vhost via a host-scoped exclusion plugin (`SecRule REQUEST_HEADERS:Host "@streq <host>" "id:...,phase:1,pass,nolog,ctl:ruleRemoveById=950140"`). Do not disable globally. |
 
 ## Reporting false positives
 If you find a false positive that this plugin does not cover then please open a new issue or pull request, if creating an issue then please include the following details:

--- a/README.md
+++ b/README.md
@@ -29,12 +29,24 @@ What this plugin does so far:
 - Block known security scanner user agents like nikto, sqlmap, wpscan (configurable, default: non-block) (PL2)
 - Block XDebug and phpinfo debug probe parameters (configurable, default: block) (PL1)
 - Block code injection patterns in wp-login.php POST parameters (configurable, default: block) (PL1)
-- Block dangerous wp-admin endpoints like install.php and setup-config.php (configurable, default: non-block) (PL2)
+- Block dangerous wp-admin endpoints — upgrade.php, wp-activate.php (configurable, default: block) (PL2)
 - IP-based rate limiting for wp-login.php (configurable, default: 5 attempts per 60 seconds, replies with HTTP 429 per RFC 6585) (PL1)
 - GeoIP-based access control for wp-login.php (configurable, default: disabled) (PL1)
 - Automatic IP reputation blocklist blocking all requests from listed IPs/CIDRs (configurable, default: disabled) (PL1)
 - Trusted-proxy pinning for X-Forwarded-For (configurable, default: disabled — backward compatible) (PL1)
 - IPv6-aware client-IP resolution and private-network whitelisting (loopback + RFC 1918 + IPv6 `::1` + ULA `fc00::/7`)
+- Strip version-disclosure response headers — X-Pingback, X-Powered-By, REST Link rel=api.w.org (configurable, default: block) (PL1)
+- Hard-block info-leak paths in phase:1 — readme.html, license.txt, .user.ini, wp-admin/install.php, wp-admin/setup-config.php, wp-includes/wlwmanifest.xml, wp-content/debug.log (configurable, default: block) (PL1)
+- Block CVE-2018-6389 DoS — long `?load=` on wp-admin/load-scripts.php and load-styles.php (configurable, default: block) (PL1)
+- Block VCS / dotfile probes — .env, .git/, .svn/, .hg/, .bzr/, .htpasswd, .DS_Store (configurable, default: block) (PL1)
+- Block wp-config backup variants — .save, .old, .new, .dist, .sample, .copy, ~, numeric .1/.2 (configurable, default: block) (PL1)
+- Block plugin/theme readme.txt version-disclosure probes (configurable, default: non-block — wp-cli reads these) (PL2)
+- Block PHP stream wrappers in args — php://, data://, expect://, file://, phar://, glob://, zip://, compress.zlib://, compress.bzip2:// (configurable, default: block) (PL1)
+- Block known-CVE plugin signatures — SureTriggers/OttoKit (CVE-2025-3102, CVE-2025-27007), Bricks Builder (CVE-2024-25600) (configurable, default: block) (PL1)
+- Block uncommon HTTP methods on /wp-admin/, /wp-login.php, /xmlrpc.php, /wp-cron.php — TRACE/TRACK/DEBUG/PROPFIND/MKCOL/COPY/MOVE/LOCK/UNLOCK/PUT/DELETE/PATCH (configurable, default: block) (PL1)
+- Block legacy CVE scanner probes — revslider, timthumb, WP Symposium, MailPoet wysija_captcha, wp-file-manager, Duplicator installer (configurable, default: block) (PL1)
+- BREACH/CRIME compression side-channel mitigation — strip Accept-Encoding on /wp-admin/, /wp-login.php, /wp-json/* so secret-bearing responses serve uncompressed (configurable, default: block) (PL1)
+- Block public /author/<slug>/ archive pages (configurable, default: non-block — most blogs expose these) (PL2)
 
 ## IP Whitelisting
 
@@ -107,7 +119,7 @@ The plugin includes IP-based rate limiting for `wp-login.php` to prevent brute f
 Uncomment these in `plugins/wordpress-hardening-config.conf` to override defaults:
 
 ```bash
-# Reduce to 3 attempts
+# Reduce to 3 attempts (window remains 60s)
 #SecAction "id:9522049,phase:1,nolog,pass,t:none,setvar:tx.wphard.ratelimit_login_attempts=3"
 
 # Change the window (allowed values: 30, 60, 120, 300, 600 — any other value
@@ -157,7 +169,7 @@ Blocks access to `wp-login.php` for clients from countries not in the allowed li
 **To enable:**
 1. Uncomment the SecAction in `plugins/wordpress-hardening-config.conf`:
    ```bash
-   SecAction "id:9522052,phase:1,nolog,pass,t:none,setvar:'tx.wphard.geoip_login_enabled=1'"
+   SecAction "id:9522902,phase:1,nolog,pass,t:none,setvar:'tx.wphard.geoip_login_enabled=1'"
    ```
 2. Populate `plugins/wordpress-hardening-login-countries.data` with the ISO codes of countries you want to allow (**lowercase, one per line**):
    ```
@@ -187,7 +199,7 @@ Blocks **all requests** (not just login attempts) from IP addresses listed in `p
 **To enable:**
 1. Uncomment the SecAction in `plugins/wordpress-hardening-config.conf`:
    ```bash
-   SecAction "id:9522053,phase:1,nolog,pass,t:none,setvar:'tx.wphard.ip_reputation_enabled=1'"
+   SecAction "id:9522903,phase:1,nolog,pass,t:none,setvar:'tx.wphard.ip_reputation_enabled=1'"
    ```
 2. Populate `plugins/wordpress-hardening-ip-reputation.data` with known bad IPs and CIDRs (one per line):
    ```
@@ -208,7 +220,8 @@ The plugin uses the allocated range **9522000-9522999**. Major buckets:
 | Range | Purpose |
 |---|---|
 | `9522010`-`9522055` | Config-knob `SecAction`s (commented examples in `config.conf`) |
-| `9522012`-`9522050` | Default-value setters (in `before.conf`) |
+| `9522012`-`9522050` | Default-value setters (in `before.conf`, IPv6/proxy series) |
+| `9522071`-`9522081` | Default-value setters (in `before.conf`, audit-round-4 protections) |
 | `9522060`-`9522065` | Client-IP resolver (`REMOTE_ADDR`, XFF v4/v6, trusted-proxy gate, `client_is_private`) |
 | `9522099` | Plugin kill-switch (removes 9522000-9522998) |
 | `9522101`-`9522111` | xmlrpc / user-enumeration / REST API / admin-login / wp-cron blocks |

--- a/plugins/wordpress-hardening-before.conf
+++ b/plugins/wordpress-hardening-before.conf
@@ -699,30 +699,33 @@ SecRule TX:wphard.block_legacy_cves "@eq 1" \
   SecRule REQUEST_URI "@rx (?:revslider_(?:show_image|ajax_action)|timthumb\.php|/wp-symposium/|/mailpoet/.*wysija[_-]?captcha|/wp-file-manager/.*connector\.minimal\.php|installer-backup\.php|installer\.php\?dup-uninstall)"
 
 # ----------------------------------------------------------------------------
-# BREACH attack mitigation (CRIME variant against HTTPS).
+# BREACH attack surface marker (CRIME variant against HTTPS).
 # ----------------------------------------------------------------------------
 # BREACH leaks secrets (CSRF nonces, session cookies) from gzip/brotli-
 # compressed HTTPS responses when the response contains both a secret and
 # attacker-controllable reflected input. The attacker observes ciphertext
 # length to confirm guess-by-guess matches against the secret.
 #
-# Application-layer fixes (mask secrets, decouple input, randomize per
-# response) require WordPress-core changes. The WAF-deployable mitigation
-# is to strip Accept-Encoding from requests to paths that mix secrets +
-# reflected input — the backend then serves those responses uncompressed
-# and the side channel disappears.
-#
-# Coverage:
+# Real mitigation: strip the response's Content-Encoding (i.e. don't compress)
+# on paths that mix authenticated secrets with reflected input:
 #   /wp-admin/*       — nonces on every page, search/query args reflected
 #   /wp-login.php     — redirect_to, login form nonces
 #   /wp-json/*        — REST nonces (X-WP-Nonce embedded in HTML responses)
 #
-# Public/anonymous pages (homepage, posts, /wp-content/) keep compression
-# because they don't contain authenticated secrets. Static assets under
-# /wp-content/ and /wp-includes/ are unaffected.
+# This is best done at the reverse-proxy layer, NOT in ModSecurity. For Angie /
+# nginx, add to the matching location blocks:
+#     proxy_set_header Accept-Encoding "";   # tell upstream not to compress
+#     gzip off;
+#     brotli off;                            # if brotli is enabled
+# or, for fastcgi backends:
+#     fastcgi_param HTTP_ACCEPT_ENCODING ""; identity;
 #
-# Note: ctl:requestHeaderRemove is the documented mechanism; the upstream
-# backend then sees no Accept-Encoding and defaults to identity encoding.
+# ModSecurity v2 (and the secrules-parsing engine used in CI) does not
+# implement `ctl:requestHeaderRemove`, so we cannot strip the request header
+# from inside this plugin. This rule therefore exists only as a *detection*
+# marker — when block_breach_compression is enabled, every request to a
+# BREACH-vulnerable path is tagged in the audit log so operators can verify
+# they have configured the proxy-side stripping correctly.
 # ----------------------------------------------------------------------------
 SecRule TX:wphard.block_breach_compression "@eq 1" \
   "id:9522121,\
@@ -738,8 +741,7 @@ SecRule TX:wphard.block_breach_compression "@eq 1" \
   pass,\
   log,\
   auditlog,\
-  msg:'Wordpress hardening: BREACH mitigation — stripped Accept-Encoding on sensitive path',\
-  ctl:requestHeaderRemove=Accept-Encoding"
+  msg:'Wordpress hardening: BREACH-sensitive path — verify proxy strips Accept-Encoding on this URI'"
   SecRule REQUEST_URI "@rx ^/(?:wp-admin(?:/|$|\?)|wp-login\.php|wp-json(?:/|$|\?))"
 
 # Check if xmlrpc should be blocked and if not, skip.
@@ -1703,17 +1705,27 @@ SecAction "id:9522604,phase:2,pass,nolog"
 SecMarker "END_WPHARD_IP_REPUTATION"
 
 # ============================================================================
-# RESPONSE HEADER VERSION-DISCLOSURE STRIPPING (phase:3)
+# RESPONSE HEADER VERSION-DISCLOSURE DETECTION (phase:3)
 # ----------------------------------------------------------------------------
 # WordPress and several plugins leak version / endpoint hints via response
-# headers. We strip the cheap-to-remove ones here. Note: the <meta name=
-# "generator"> tag and ?ver= asset query strings live in the response body
-# and must be removed at WordPress level (filters: the_generator,
-# style_loader_src, script_loader_src) — ModSecurity cannot rewrite bodies
-# reliably.
+# headers (X-Pingback, X-Powered-By, REST Link rel=api.w.org). Stripping
+# them is a one-line proxy config — Angie/nginx:
+#     proxy_hide_header X-Pingback;
+#     proxy_hide_header X-Powered-By;
+#     more_clear_headers "Link";   # or hide_header if appropriate
+#
+# ModSecurity v2 (and the secrules-parsing engine used in CI) does not
+# support `ctl:responseHeaderRemove`, so we cannot strip from inside this
+# plugin. These rules exist as *detection* markers — they log when a
+# leaking response header is observed so operators can verify the proxy-
+# side stripping is configured.
+#
+# Note: the <meta name="generator"> tag and ?ver= asset query strings
+# live in the response body and must be removed at WordPress level
+# (filters: the_generator, style_loader_src, script_loader_src).
 # ============================================================================
 
-#Check if version disclosure stripping should run; skip otherwise
+#Check if version disclosure detection should run; skip otherwise
 SecRule TX:wphard.block_version_disclosure "@eq 0" \
   "phase:3,\
   id:9522700,\
@@ -1723,7 +1735,7 @@ SecRule TX:wphard.block_version_disclosure "@eq 0" \
 
 SecMarker "BEGIN_WPHARD_VERSION_DISCLOSURE"
 
-# Strip X-Pingback header (advertises /xmlrpc.php to scanners)
+# Detect X-Pingback header (advertises /xmlrpc.php to scanners)
 SecRule RESPONSE_HEADERS:X-Pingback "@rx ^" \
   "id:9522701,\
   phase:3,\
@@ -1735,9 +1747,9 @@ SecRule RESPONSE_HEADERS:X-Pingback "@rx ^" \
   pass,\
   log,\
   auditlog,\
-  ctl:responseHeaderRemove=X-Pingback"
+  msg:'Wordpress hardening: X-Pingback response header leak — verify proxy_hide_header'"
 
-# Strip WordPress version response header if any plugin sets it
+# Detect WordPress / PHP X-Powered-By leakage
 SecRule RESPONSE_HEADERS:X-Powered-By "@rx (?i)wordpress|php" \
   "id:9522702,\
   phase:3,\
@@ -1749,9 +1761,9 @@ SecRule RESPONSE_HEADERS:X-Powered-By "@rx (?i)wordpress|php" \
   pass,\
   log,\
   auditlog,\
-  ctl:responseHeaderRemove=X-Powered-By"
+  msg:'Wordpress hardening: X-Powered-By response header leak — verify proxy_hide_header'"
 
-# Strip REST API discovery Link header (rel=https://api.w.org/)
+# Detect REST API discovery Link header (rel=https://api.w.org/)
 SecRule RESPONSE_HEADERS:Link "@rx api\.w\.org" \
   "id:9522703,\
   phase:3,\
@@ -1763,6 +1775,6 @@ SecRule RESPONSE_HEADERS:Link "@rx api\.w\.org" \
   pass,\
   log,\
   auditlog,\
-  ctl:responseHeaderRemove=Link"
+  msg:'Wordpress hardening: REST api.w.org Link response header leak — verify proxy_hide_header / more_clear_headers'"
 
 SecMarker "END_WPHARD_VERSION_DISCLOSURE"

--- a/plugins/wordpress-hardening-before.conf
+++ b/plugins/wordpress-hardening-before.conf
@@ -152,13 +152,109 @@ SecRule &TX:wphard.block_login_injection "@eq 0" \
   nolog,\
   setvar:tx.wphard.block_login_injection=1"
 
-#Check if variable exist and if not, set default (dangerous admin: OFF by default)
+#Check if variable exist and if not, set default (dangerous admin: ON by default — overlap with 9522100 narrowed)
 SecRule &TX:wphard.block_dangerous_admin "@eq 0" \
   "phase:1,\
   id:9522038,\
   pass,\
   nolog,\
-  setvar:tx.wphard.block_dangerous_admin=0"
+  setvar:tx.wphard.block_dangerous_admin=1"
+
+#Check if variable exist and if not, set default (version disclosure stripping: ON by default)
+SecRule &TX:wphard.block_version_disclosure "@eq 0" \
+  "phase:1,\
+  id:9522039,\
+  pass,\
+  nolog,\
+  setvar:tx.wphard.block_version_disclosure=1"
+
+#Check if variable exist and if not, set default (info-leak file blocking: ON by default)
+SecRule &TX:wphard.block_info_leak_files "@eq 0" \
+  "phase:1,\
+  id:9522071,\
+  pass,\
+  nolog,\
+  setvar:tx.wphard.block_info_leak_files=1"
+
+#Check if variable exist and if not, set default (CVE-2018-6389 load-scripts DoS: ON by default)
+SecRule &TX:wphard.block_load_scripts_dos "@eq 0" \
+  "phase:1,\
+  id:9522072,\
+  pass,\
+  nolog,\
+  setvar:tx.wphard.block_load_scripts_dos=1"
+
+#Check if variable exist and if not, set default (.env / .git / .svn / VCS paths: ON by default)
+SecRule &TX:wphard.block_vcs_paths "@eq 0" \
+  "phase:1,\
+  id:9522073,\
+  pass,\
+  nolog,\
+  setvar:tx.wphard.block_vcs_paths=1"
+
+#Check if variable exist and if not, set default (wp-config backup variants: ON by default)
+SecRule &TX:wphard.block_wpconfig_backups "@eq 0" \
+  "phase:1,\
+  id:9522074,\
+  pass,\
+  nolog,\
+  setvar:tx.wphard.block_wpconfig_backups=1"
+
+#Check if variable exist and if not, set default (plugin/theme version disclosure via readme: OFF by default — may break legitimate use)
+SecRule &TX:wphard.block_plugin_readme "@eq 0" \
+  "phase:1,\
+  id:9522075,\
+  pass,\
+  nolog,\
+  setvar:tx.wphard.block_plugin_readme=0"
+
+#Check if variable exist and if not, set default (PHP wrapper / LFI-RFI in args: ON by default)
+SecRule &TX:wphard.block_php_wrappers "@eq 0" \
+  "phase:1,\
+  id:9522076,\
+  pass,\
+  nolog,\
+  setvar:tx.wphard.block_php_wrappers=1"
+
+#Check if variable exist and if not, set default (SureTriggers + Bricks Builder CVE signatures: ON by default)
+SecRule &TX:wphard.block_known_plugin_cves "@eq 0" \
+  "phase:1,\
+  id:9522077,\
+  pass,\
+  nolog,\
+  setvar:tx.wphard.block_known_plugin_cves=1"
+
+#Check if variable exist and if not, set default (HTTP method restriction on /wp-* paths: ON by default)
+SecRule &TX:wphard.block_uncommon_methods "@eq 0" \
+  "phase:1,\
+  id:9522078,\
+  pass,\
+  nolog,\
+  setvar:tx.wphard.block_uncommon_methods=1"
+
+#Check if variable exist and if not, set default (legacy CVE scanner signatures: ON by default)
+SecRule &TX:wphard.block_legacy_cves "@eq 0" \
+  "phase:1,\
+  id:9522079,\
+  pass,\
+  nolog,\
+  setvar:tx.wphard.block_legacy_cves=1"
+
+#Check if variable exist and if not, set default (BREACH compression side-channel mitigation: ON by default)
+SecRule &TX:wphard.block_breach_compression "@eq 0" \
+  "phase:1,\
+  id:9522080,\
+  pass,\
+  nolog,\
+  setvar:tx.wphard.block_breach_compression=1"
+
+#Check if variable exist and if not, set default (block public /author/ archives: OFF by default — most blogs expect these pages to be public)
+SecRule &TX:wphard.block_author_archives "@eq 0" \
+  "phase:1,\
+  id:9522081,\
+  pass,\
+  nolog,\
+  setvar:tx.wphard.block_author_archives=0"
 
 # IP-BASED RATE LIMITING FOR WP-LOGIN.PHP
 # Lock out an IP after X failed login attempts for Y seconds
@@ -180,13 +276,11 @@ SecRule &TX:wphard.ratelimit_login_attempts "@eq 0" \
   nolog,\
   setvar:tx.wphard.ratelimit_login_attempts=5"
 
-#Check if variable exist and if not, set default (window: 60 seconds by default)
-SecRule &TX:wphard.ratelimit_login_window "@eq 0" \
-  "phase:1,\
-  id:9522044,\
-  pass,\
-  nolog,\
-  setvar:tx.wphard.ratelimit_login_window=60"
+# Note: ratelimit_login_window is intentionally NOT configurable. ModSecurity's
+# `expirevar` does not accept macro expansion for its TTL, so the counter window
+# is hardcoded to 60 seconds in rule 9522411. A previous version of this plugin
+# exposed tx.wphard.ratelimit_login_window as a tunable; it had no effect on
+# behaviour, only on the log message, and has been removed to avoid confusion.
 
 # GEOIP-BASED ACCESS CONTROL FOR WP-LOGIN.PHP
 # Block wp-login.php for clients whose country is not in the allowed list.
@@ -337,6 +431,316 @@ SecRule TX:wphard.client_ip "@rx ^(?:127\.[0-9]+\.[0-9]+\.[0-9]+|10\.[0-9]+\.[0-
   pass,\
   nolog,\
   setvar:tx.wphard.client_is_private=1"
+# ============================================================================
+# INFO-LEAK FILE HARD-BLOCK (phase:1)
+# ----------------------------------------------------------------------------
+# Block well-known WordPress info-leak paths in phase:1 so the rule fires
+# *before* any upstream location-block redirect (which would otherwise 302
+# the probe to a confusing target and bypass ModSec phase:2). These paths
+# carry no legitimate traffic for an installed site:
+#   /readme.html, /license.txt          (WordPress version disclosure)
+#   /.user.ini                          (PHP per-directory config probe)
+#   /wp-admin/install.php               (installer — completed installs only)
+#   /wp-admin/setup-config.php          (installer step 2)
+#   /wp-includes/wlwmanifest.xml        (Windows Live Writer manifest)
+#   /wp-content/debug.log               (WP_DEBUG_LOG output)
+# Returns 403 deterministically; respects the block_info_leak_files toggle.
+# ============================================================================
+SecRule TX:wphard.block_info_leak_files "@eq 1" \
+  "id:9522100,\
+  phase:1,\
+  chain,\
+  t:lowercase,t:normalizePath,\
+  tag:'wordpress',\
+  tag:'info-leak',\
+  tag:'paranoia-level/1',\
+  accuracy:'9',\
+  maturity:'1',\
+  severity:'NOTICE',\
+  ver:'WPHARD/1.0.0',\
+  block,\
+  logdata:'Request URI %{REQUEST_URI}',\
+  msg:'Wordpress hardening: blocked info-leak path',\
+  setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+  SecRule REQUEST_URI "@rx ^/(?:readme\.html|license\.txt|\.user\.ini|wp-admin/(?:install|setup-config)\.php|wp-includes/wlwmanifest\.xml|wp-content/debug\.log)(?:$|\?)"
+
+# ----------------------------------------------------------------------------
+# CVE-2018-6389: /wp-admin/load-scripts.php and /wp-admin/load-styles.php
+# accept a ?load=handle1,handle2,... parameter and concatenate the listed
+# core JS/CSS files. Unauthenticated by design. An attacker can request
+# every registered handle in one URL to force WordPress to load ~all of
+# wp-includes, exhausting CPU/memory. Block when load= is suspiciously long
+# (>= ~10 handles ≈ length > 80 chars including commas) — legitimate WP
+# admin pages chain a few handles at most.
+# ----------------------------------------------------------------------------
+SecRule TX:wphard.block_load_scripts_dos "@eq 1" \
+  "id:9522112,\
+  phase:1,\
+  chain,\
+  t:lowercase,t:normalizePath,\
+  tag:'wordpress',\
+  tag:'cve-2018-6389',\
+  tag:'dos',\
+  tag:'paranoia-level/1',\
+  accuracy:'9',\
+  maturity:'1',\
+  severity:'WARNING',\
+  ver:'WPHARD/1.0.0',\
+  block,\
+  logdata:'Request URI %{REQUEST_URI}',\
+  msg:'Wordpress hardening: CVE-2018-6389 load-scripts/load-styles DoS attempt',\
+  setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+  SecRule REQUEST_URI "@rx ^/wp-admin/load-(?:scripts|styles)\.php\?.*\bload(?:%5B%5D|\[\])?=[^&]{80,}"
+
+# ----------------------------------------------------------------------------
+# Block access to VCS metadata and dotfile secrets.
+#   /.env, /.env.local, /.env.*       (Laravel/CI conventions creeping into WP)
+#   /.git/, /.svn/, /.hg/, /.bzr/     (repo metadata exposing source+history)
+#   /.htpasswd, /.htaccess (in body)  (already in 9522206 but we want phase:1)
+# ----------------------------------------------------------------------------
+SecRule TX:wphard.block_vcs_paths "@eq 1" \
+  "id:9522113,\
+  phase:1,\
+  chain,\
+  t:lowercase,t:normalizePath,\
+  tag:'wordpress',\
+  tag:'info-leak',\
+  tag:'vcs-metadata',\
+  tag:'paranoia-level/1',\
+  accuracy:'9',\
+  maturity:'1',\
+  severity:'NOTICE',\
+  ver:'WPHARD/1.0.0',\
+  block,\
+  logdata:'Request URI %{REQUEST_URI}',\
+  msg:'Wordpress hardening: blocked VCS / dotfile probe',\
+  setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+  SecRule REQUEST_URI "@rx (?:^|/)(?:\.env(?:\.[a-z0-9_-]+)?|\.git(?:/|$|ignore|attributes|modules|config|hooks)|\.svn(?:/|$|/entries|/wc\.db)|\.hg(?:/|$)|\.bzr(?:/|$)|\.ds_store|\.htpasswd)(?:$|/|\?)"
+
+# ----------------------------------------------------------------------------
+# Block wp-config.php backup variants. The base 9522206 regex catches some
+# (.bak/.orig/.swp) but misses .save, .old, .php~, .php.txt, .php.bak, and
+# numeric backups (wp-config.php.1, .2, etc). All of these would serve the
+# raw file as text since they aren't .php anymore.
+# ----------------------------------------------------------------------------
+SecRule TX:wphard.block_wpconfig_backups "@eq 1" \
+  "id:9522114,\
+  phase:1,\
+  chain,\
+  t:lowercase,t:normalizePath,\
+  tag:'wordpress',\
+  tag:'info-leak',\
+  tag:'config-leak',\
+  tag:'paranoia-level/1',\
+  accuracy:'9',\
+  maturity:'1',\
+  severity:'CRITICAL',\
+  ver:'WPHARD/1.0.0',\
+  block,\
+  logdata:'Request URI %{REQUEST_URI}',\
+  msg:'Wordpress hardening: wp-config backup variant probe',\
+  setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+  SecRule REQUEST_URI "@rx ^/wp-config(?:\.php)?(?:\.(?:bak|backup|save|old|new|orig|tmp|swp|swo|txt|inc|dist|sample|copy|[0-9]+)|~)(?:$|\?)"
+
+# ----------------------------------------------------------------------------
+# Optional: block plugin/theme version disclosure via readme.txt and
+# style.css headers. Attackers scrape these to map installed-version → CVE.
+# Disabled by default because some legitimate tooling fetches readme.txt
+# (wp-cli, update checkers) — enable only behind a tight allowlist or when
+# you accept that minor breakage.
+# ----------------------------------------------------------------------------
+SecRule TX:wphard.block_plugin_readme "@eq 1" \
+  "id:9522115,\
+  phase:1,\
+  chain,\
+  t:lowercase,t:normalizePath,\
+  tag:'wordpress',\
+  tag:'info-leak',\
+  tag:'version-disclosure',\
+  tag:'paranoia-level/2',\
+  accuracy:'8',\
+  maturity:'1',\
+  severity:'NOTICE',\
+  ver:'WPHARD/1.0.0',\
+  block,\
+  logdata:'Request URI %{REQUEST_URI}',\
+  msg:'Wordpress hardening: plugin/theme version disclosure probe',\
+  setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+  SecRule REQUEST_URI "@rx ^/wp-content/(?:plugins|themes|mu-plugins)/[^/]+/(?:readme(?:\.txt|\.md)|changelog\.txt|license\.txt)(?:$|\?)"
+
+# ----------------------------------------------------------------------------
+# PHP stream wrappers in any request argument — classic LFI/RFI vector.
+# php://input, php://filter, data://, expect://, file://, phar://, glob://,
+# zip://. No legitimate WordPress request should contain these in a URL arg
+# or POST body. Match across ARGS and REQUEST_URI (URL-decoded once by ModSec).
+# ----------------------------------------------------------------------------
+SecRule TX:wphard.block_php_wrappers "@eq 1" \
+  "id:9522116,\
+  phase:2,\
+  chain,\
+  t:none,t:urlDecodeUni,t:lowercase,\
+  tag:'wordpress',\
+  tag:'lfi-rfi',\
+  tag:'php-wrappers',\
+  tag:'paranoia-level/1',\
+  accuracy:'9',\
+  maturity:'1',\
+  severity:'CRITICAL',\
+  ver:'WPHARD/1.0.0',\
+  block,\
+  capture,\
+  logdata:'Matched %{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
+  msg:'Wordpress hardening: PHP stream wrapper / LFI-RFI probe',\
+  setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+  SecRule ARGS|REQUEST_URI "@rx (?:^|[^a-z0-9])(?:php|data|expect|file|phar|glob|zip|compress\.(?:zlib|bzip2))://"
+
+# ----------------------------------------------------------------------------
+# Known-CVE plugin signatures still actively exploited in 2026:
+#   - SureTriggers / OttoKit (CVE-2025-3102, CVE-2025-27007): unauth admin
+#     creation via /wp-json/sure-triggers/v1/* with a bypassed ST-Authorization
+#     header. Any unauthenticated POST to this namespace is suspicious for the
+#     vast majority of sites that don't use SureTriggers.
+#   - Bricks Builder (CVE-2024-25600): unauth RCE via /wp-json/bricks/v1/
+#     render_element with a "php" element type that reaches a code-execution
+#     sink. Block the render_element endpoint when unauthenticated.
+# ----------------------------------------------------------------------------
+SecRule TX:wphard.block_known_plugin_cves "@eq 1" \
+  "id:9522117,\
+  phase:2,\
+  chain,\
+  t:lowercase,t:normalizePath,\
+  tag:'wordpress',\
+  tag:'known-cve',\
+  tag:'suretriggers',\
+  tag:'paranoia-level/1',\
+  accuracy:'9',\
+  maturity:'1',\
+  severity:'CRITICAL',\
+  ver:'WPHARD/1.0.0',\
+  block,\
+  logdata:'SureTriggers REST probe: %{REQUEST_URI}',\
+  msg:'Wordpress hardening: SureTriggers/OttoKit CVE-2025-3102/27007 probe',\
+  setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+  SecRule REQUEST_URI "@rx ^/(?:index\.php\?rest_route=/?|wp-json/)sure-triggers/v1/"
+
+SecRule TX:wphard.block_known_plugin_cves "@eq 1" \
+  "id:9522118,\
+  phase:2,\
+  chain,\
+  t:lowercase,\
+  tag:'wordpress',\
+  tag:'known-cve',\
+  tag:'bricks-builder',\
+  tag:'paranoia-level/1',\
+  accuracy:'9',\
+  maturity:'1',\
+  severity:'CRITICAL',\
+  ver:'WPHARD/1.0.0',\
+  block,\
+  logdata:'Bricks render_element probe: %{REQUEST_URI}',\
+  msg:'Wordpress hardening: Bricks Builder CVE-2024-25600 RCE probe',\
+  setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+  SecRule REQUEST_URI "@rx ^/(?:index\.php\?rest_route=/?|wp-json/)bricks/v1/render_element"
+
+# ----------------------------------------------------------------------------
+# HTTP method restriction on WordPress paths. Only GET/POST/HEAD/OPTIONS are
+# legitimate on /wp-admin, /wp-login.php, /xmlrpc.php. /wp-json may also use
+# PUT/DELETE/PATCH for authenticated REST writes, so it's excluded here.
+# Blocks TRACE/TRACK/DEBUG/PROPFIND/MKCOL/COPY/MOVE/LOCK/UNLOCK probes.
+# ----------------------------------------------------------------------------
+SecRule TX:wphard.block_uncommon_methods "@eq 1" \
+  "id:9522119,\
+  phase:1,\
+  chain,\
+  t:lowercase,t:normalizePath,\
+  tag:'wordpress',\
+  tag:'http-method',\
+  tag:'paranoia-level/1',\
+  accuracy:'9',\
+  maturity:'1',\
+  severity:'WARNING',\
+  ver:'WPHARD/1.0.0',\
+  block,\
+  logdata:'Method %{REQUEST_METHOD} on %{REQUEST_URI}',\
+  msg:'Wordpress hardening: uncommon HTTP method on WP path',\
+  setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+  SecRule REQUEST_URI "@rx ^/(?:wp-admin/|wp-login\.php|xmlrpc\.php|wp-cron\.php)" \
+    "chain"
+    SecRule REQUEST_METHOD "!@rx ^(?:GET|POST|HEAD|OPTIONS)$"
+
+# ----------------------------------------------------------------------------
+# Legacy CVE scanner noise reduction. These plugins are long dead or patched
+# years ago but still drive a constant stream of background-noise scans.
+# Returning 403 here means our backend never serves the request and our logs
+# stay readable.
+#   - Slider Revolution (revslider) LFI / RCE — CVE-2014-9734, 2015-3324
+#   - TimThumb RFI — 2011 era
+#   - WP Symposium 0-day — 2014
+#   - MailPoet wysija captcha LFI — 2014
+#   - File Manager (wp-file-manager) connector.minimal.php RCE — CVE-2020-25213
+#   - Duplicator package exposure — CVE-2020-11738
+# ----------------------------------------------------------------------------
+SecRule TX:wphard.block_legacy_cves "@eq 1" \
+  "id:9522120,\
+  phase:1,\
+  chain,\
+  t:lowercase,t:normalizePath,t:urlDecodeUni,\
+  tag:'wordpress',\
+  tag:'legacy-cve',\
+  tag:'paranoia-level/1',\
+  accuracy:'9',\
+  maturity:'1',\
+  severity:'NOTICE',\
+  ver:'WPHARD/1.0.0',\
+  block,\
+  logdata:'Legacy CVE probe: %{REQUEST_URI}',\
+  msg:'Wordpress hardening: legacy CVE scanner probe',\
+  setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+  SecRule REQUEST_URI "@rx (?:revslider_(?:show_image|ajax_action)|timthumb\.php|/wp-symposium/|/mailpoet/.*wysija[_-]?captcha|/wp-file-manager/.*connector\.minimal\.php|installer-backup\.php|installer\.php\?dup-uninstall)"
+
+# ----------------------------------------------------------------------------
+# BREACH attack mitigation (CRIME variant against HTTPS).
+# ----------------------------------------------------------------------------
+# BREACH leaks secrets (CSRF nonces, session cookies) from gzip/brotli-
+# compressed HTTPS responses when the response contains both a secret and
+# attacker-controllable reflected input. The attacker observes ciphertext
+# length to confirm guess-by-guess matches against the secret.
+#
+# Application-layer fixes (mask secrets, decouple input, randomize per
+# response) require WordPress-core changes. The WAF-deployable mitigation
+# is to strip Accept-Encoding from requests to paths that mix secrets +
+# reflected input — the backend then serves those responses uncompressed
+# and the side channel disappears.
+#
+# Coverage:
+#   /wp-admin/*       — nonces on every page, search/query args reflected
+#   /wp-login.php     — redirect_to, login form nonces
+#   /wp-json/*        — REST nonces (X-WP-Nonce embedded in HTML responses)
+#
+# Public/anonymous pages (homepage, posts, /wp-content/) keep compression
+# because they don't contain authenticated secrets. Static assets under
+# /wp-content/ and /wp-includes/ are unaffected.
+#
+# Note: ctl:requestHeaderRemove is the documented mechanism; the upstream
+# backend then sees no Accept-Encoding and defaults to identity encoding.
+# ----------------------------------------------------------------------------
+SecRule TX:wphard.block_breach_compression "@eq 1" \
+  "id:9522121,\
+  phase:1,\
+  chain,\
+  t:lowercase,t:normalizePath,\
+  tag:'wordpress',\
+  tag:'breach',\
+  tag:'crime',\
+  tag:'compression-side-channel',\
+  tag:'paranoia-level/1',\
+  ver:'WPHARD/1.0.0',\
+  pass,\
+  log,\
+  auditlog,\
+  msg:'Wordpress hardening: BREACH mitigation — stripped Accept-Encoding on sensitive path',\
+  ctl:requestHeaderRemove=Accept-Encoding"
+  SecRule REQUEST_URI "@rx ^/(?:wp-admin(?:/|$|\?)|wp-login\.php|wp-json(?:/|$|\?))"
 
 # Check if xmlrpc should be blocked and if not, skip.
 SecRule &TX:wphard.block_xmlrpc "@eq 0" \
@@ -423,6 +827,31 @@ SecRule REQUEST_URI "@rx (?:[/?&]author=[0-9]+)|(?:/wp/v2/users/?(?:\?|$))|(?:/w
 
 SecMarker "END_WPHARD_USER_ENUMERATION"
 # ID inventory: 9522156 added 2026-05-21 for user-enum private-IP whitelist.
+
+# ----------------------------------------------------------------------------
+# Optional: block /author/<slug>/ archive pages. WordPress exposes one such
+# page per author by default — most blogs treat these as legitimate public
+# pages, so this is OFF by default. Enable on tightly-controlled sites where
+# author archives are not part of the intended public surface.
+# ----------------------------------------------------------------------------
+SecRule TX:wphard.block_author_archives "@eq 1" \
+  "id:9522122,\
+  phase:2,\
+  chain,\
+  t:lowercase,t:normalizePath,t:trim,t:urlDecodeUni,\
+  tag:'wordpress',\
+  tag:'enumeration',\
+  tag:'author-archive',\
+  tag:'paranoia-level/2',\
+  accuracy:'9',\
+  maturity:'1',\
+  severity:'NOTICE',\
+  ver:'WPHARD/1.0.0',\
+  block,\
+  logdata:'Request URI %{REQUEST_URI}',\
+  msg:'Wordpress hardening: /author/ archive access blocked',\
+  setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
+  SecRule REQUEST_URI "@rx ^/author/"
 
 # Check if restapi should be blocked and if not, skip
 SecRule TX:wphard.block_rest_api "@eq 0" \
@@ -993,6 +1422,8 @@ SecRule TX:wphard.block_dangerous_admin "@eq 0" \
 SecMarker "BEGIN_WPHARD_BLOCK_DANGEROUS_ADMIN"
 
 # PL2 rule — only enforce at detection paranoia level >= 2.
+# install.php and setup-config.php are already hard-blocked in phase:1 by 9522100
+# (info-leak rule), so this rule only needs to cover upgrade.php and wp-activate.php.
 SecRule TX:detection_paranoia_level "@lt 2" \
   "id:9522320,\
   phase:2,\
@@ -1000,7 +1431,7 @@ SecRule TX:detection_paranoia_level "@lt 2" \
   nolog,\
   skipAfter:END_WPHARD_BLOCK_DANGEROUS_ADMIN"
 
-SecRule REQUEST_FILENAME "@rx ^/wp-admin/(install|setup-config|upgrade|wp-activate)\.php" \
+SecRule REQUEST_FILENAME "@rx ^/wp-admin/(upgrade|wp-activate)\.php" \
   "id:9522317,\
   phase:2,\
   t:lowercase,t:normalizePath,t:trim,\
@@ -1270,3 +1701,68 @@ SecRule TX:wphard.client_ip "@ipMatchFromFile wordpress-hardening-ip-reputation.
 SecAction "id:9522604,phase:2,pass,nolog"
 
 SecMarker "END_WPHARD_IP_REPUTATION"
+
+# ============================================================================
+# RESPONSE HEADER VERSION-DISCLOSURE STRIPPING (phase:3)
+# ----------------------------------------------------------------------------
+# WordPress and several plugins leak version / endpoint hints via response
+# headers. We strip the cheap-to-remove ones here. Note: the <meta name=
+# "generator"> tag and ?ver= asset query strings live in the response body
+# and must be removed at WordPress level (filters: the_generator,
+# style_loader_src, script_loader_src) — ModSecurity cannot rewrite bodies
+# reliably.
+# ============================================================================
+
+#Check if version disclosure stripping should run; skip otherwise
+SecRule TX:wphard.block_version_disclosure "@eq 0" \
+  "phase:3,\
+  id:9522700,\
+  pass,\
+  nolog,\
+  skipAfter:END_WPHARD_VERSION_DISCLOSURE"
+
+SecMarker "BEGIN_WPHARD_VERSION_DISCLOSURE"
+
+# Strip X-Pingback header (advertises /xmlrpc.php to scanners)
+SecRule RESPONSE_HEADERS:X-Pingback "@rx ^" \
+  "id:9522701,\
+  phase:3,\
+  t:none,\
+  tag:'wordpress',\
+  tag:'version-disclosure',\
+  tag:'paranoia-level/1',\
+  ver:'WPHARD/1.0.0',\
+  pass,\
+  log,\
+  auditlog,\
+  ctl:responseHeaderRemove=X-Pingback"
+
+# Strip WordPress version response header if any plugin sets it
+SecRule RESPONSE_HEADERS:X-Powered-By "@rx (?i)wordpress|php" \
+  "id:9522702,\
+  phase:3,\
+  t:none,\
+  tag:'wordpress',\
+  tag:'version-disclosure',\
+  tag:'paranoia-level/1',\
+  ver:'WPHARD/1.0.0',\
+  pass,\
+  log,\
+  auditlog,\
+  ctl:responseHeaderRemove=X-Powered-By"
+
+# Strip REST API discovery Link header (rel=https://api.w.org/)
+SecRule RESPONSE_HEADERS:Link "@rx api\.w\.org" \
+  "id:9522703,\
+  phase:3,\
+  t:none,\
+  tag:'wordpress',\
+  tag:'version-disclosure',\
+  tag:'paranoia-level/1',\
+  ver:'WPHARD/1.0.0',\
+  pass,\
+  log,\
+  auditlog,\
+  ctl:responseHeaderRemove=Link"
+
+SecMarker "END_WPHARD_VERSION_DISCLOSURE"

--- a/plugins/wordpress-hardening-config.conf
+++ b/plugins/wordpress-hardening-config.conf
@@ -56,8 +56,57 @@
 #SecAction "id:9522033,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_debug_probes=1"
 # block_login_injection: Block code injection in wp-login POST parameters (default: ON)
 #SecAction "id:9522035,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_login_injection=1"
-# block_dangerous_admin: Block dangerous wp-admin endpoints (install/upgrade) (default: OFF)
-#SecAction "id:9522037,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_dangerous_admin=0"
+# block_dangerous_admin: Block wp-admin/upgrade.php and wp-admin/wp-activate.php — these are
+# rarely reached legitimately on a settled site. install.php and setup-config.php are covered
+# by block_info_leak_files at phase:1. (default: ON)
+#SecAction "id:9522037,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_dangerous_admin=1"
+# block_version_disclosure: Strip X-Pingback, X-Powered-By, and REST Link response headers (default: ON)
+# Note: the <meta generator> tag and ?ver= asset query strings live in the response body and
+# must be stripped at WordPress level (filters: the_generator, style_loader_src, script_loader_src).
+#SecAction "id:9522939,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_version_disclosure=1"
+# block_info_leak_files: Hard-block phase:1 access to readme.html, license.txt, .user.ini,
+# wp-admin/install.php, wp-admin/setup-config.php, wp-includes/wlwmanifest.xml,
+# wp-content/debug.log. Fires before any upstream redirect can preempt ModSec. (default: ON)
+#SecAction "id:9522950,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_info_leak_files=1"
+# block_load_scripts_dos: Block CVE-2018-6389 (long ?load= concat on wp-admin/load-scripts.php
+# and load-styles.php that exhausts CPU/memory). (default: ON)
+#SecAction "id:9522952,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_load_scripts_dos=1"
+# block_vcs_paths: Block .env, .git/, .svn/, .hg/, .bzr/, .htpasswd, .DS_Store probes
+# (credential/source leak paths). (default: ON)
+#SecAction "id:9522954,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_vcs_paths=1"
+# block_wpconfig_backups: Block wp-config.php backup variants — .save, .old, .new, .dist,
+# .sample, .copy, ~ suffix, numeric .1/.2, etc. (default: ON)
+#SecAction "id:9522956,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_wpconfig_backups=1"
+# block_plugin_readme: Block /wp-content/plugins/<slug>/readme.txt and theme style.css/changelog
+# version-disclosure probes used to map installed plugin → CVE. (default: OFF — some legitimate
+# tooling reads readme.txt; enable only if you accept that breakage.)
+#SecAction "id:9522958,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_plugin_readme=1"
+# block_php_wrappers: Block php://, data://, expect://, file://, phar://, glob://, zip://,
+# compress.zlib://, compress.bzip2:// in any ARG or REQUEST_URI. Classic LFI/RFI defense. (default: ON)
+#SecAction "id:9522960,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_php_wrappers=1"
+# block_known_plugin_cves: Block known-CVE plugin signatures still actively exploited —
+# SureTriggers/OttoKit (CVE-2025-3102, CVE-2025-27007) and Bricks Builder (CVE-2024-25600).
+# Disable if you actually use either plugin and need legitimate REST traffic to those routes. (default: ON)
+#SecAction "id:9522962,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_known_plugin_cves=1"
+# block_uncommon_methods: Block TRACE/TRACK/DEBUG/PROPFIND/MKCOL/COPY/MOVE/LOCK/UNLOCK/PUT/DELETE/PATCH
+# on /wp-admin/, /wp-login.php, /xmlrpc.php, /wp-cron.php. /wp-json is intentionally excluded
+# because authenticated REST writes legitimately use PUT/DELETE/PATCH. (default: ON)
+#SecAction "id:9522964,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_uncommon_methods=1"
+# block_legacy_cves: Block long-dead-but-still-scanned CVE probes — revslider, timthumb,
+# WP Symposium, MailPoet wysija_captcha, wp-file-manager connector.minimal.php, Duplicator
+# installer leaks. Pure log-noise reduction; no legitimate traffic hits these. (default: ON)
+#SecAction "id:9522966,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_legacy_cves=1"
+# block_breach_compression: Mitigate BREACH/CRIME compression side-channel against HTTPS by
+# stripping Accept-Encoding from requests to /wp-admin/, /wp-login.php, /wp-json/*. The backend
+# then serves these (secret-bearing) responses uncompressed, removing the side channel. Public
+# pages and static assets keep gzip/brotli. Trade-off: ~3–10× more bytes on admin pages, which
+# is normally fine because admin traffic is low-volume. (default: ON)
+#SecAction "id:9522968,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_breach_compression=1"
+# block_author_archives: Block /author/<slug>/ archive pages (rule 9522122). Default OFF because
+# most blogs intentionally expose author archives. Enable only if these pages are not part of the
+# intended public surface. Note: ?author=N numeric enumeration is always blocked by 9522104 under
+# block_user_enumeration — this toggle is only about the slug-form archive page.
+#SecAction "id:9522970,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_author_archives=1"
 
 # IP Whitelisting for blocked endpoints
 # By default, xmlrpc.php, wp-json, and wp-cron.php allow access from localhost and RFC 1918 private IPs.
@@ -70,7 +119,7 @@
 
 # IP-BASED RATE LIMITING FOR WP-LOGIN.PHP
 # Lock out an IP after X failed login attempts within a fixed 60-second window.
-# By default: enabled, 5 attempts per 60 seconds, whitelist: localhost + RFC 1918
+# Default: 5 attempts per 60 seconds, whitelist: localhost + RFC 1918.
 #
 # WINDOW VALUES — choose one of: 30, 60, 120, 300, 600 (seconds).
 # expirevar does not accept macros, so the plugin dispatches on the configured
@@ -100,7 +149,7 @@
 # Requests without a recognized country header are allowed through (fail-open).
 #
 # Example: Enable GeoIP login access control
-#SecAction "id:9522052,phase:1,nolog,pass,t:none,setvar:'tx.wphard.geoip_login_enabled=1'"
+#SecAction "id:9522902,phase:1,nolog,pass,t:none,setvar:'tx.wphard.geoip_login_enabled=1'"
 
 # IP REPUTATION BLOCKLIST
 # Blocks all requests originating from IPs listed in plugins/wordpress-hardening-ip-reputation.data.

--- a/plugins/wordpress-hardening-config.conf
+++ b/plugins/wordpress-hardening-config.conf
@@ -60,9 +60,12 @@
 # rarely reached legitimately on a settled site. install.php and setup-config.php are covered
 # by block_info_leak_files at phase:1. (default: ON)
 #SecAction "id:9522037,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_dangerous_admin=1"
-# block_version_disclosure: Strip X-Pingback, X-Powered-By, and REST Link response headers (default: ON)
-# Note: the <meta generator> tag and ?ver= asset query strings live in the response body and
-# must be stripped at WordPress level (filters: the_generator, style_loader_src, script_loader_src).
+# block_version_disclosure: Detect X-Pingback, X-Powered-By, and REST Link response-header
+# leaks (rules 9522701/9522702/9522703). ModSecurity v2 cannot strip response headers, so
+# this is detection-only — fire a proxy_hide_header / more_clear_headers in Angie/nginx for
+# the actual strip. The <meta generator> tag and ?ver= asset query strings live in the
+# response body and must be stripped at WordPress level (filters: the_generator,
+# style_loader_src, script_loader_src). (default: ON)
 #SecAction "id:9522939,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_version_disclosure=1"
 # block_info_leak_files: Hard-block phase:1 access to readme.html, license.txt, .user.ini,
 # wp-admin/install.php, wp-admin/setup-config.php, wp-includes/wlwmanifest.xml,
@@ -96,11 +99,11 @@
 # WP Symposium, MailPoet wysija_captcha, wp-file-manager connector.minimal.php, Duplicator
 # installer leaks. Pure log-noise reduction; no legitimate traffic hits these. (default: ON)
 #SecAction "id:9522966,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_legacy_cves=1"
-# block_breach_compression: Mitigate BREACH/CRIME compression side-channel against HTTPS by
-# stripping Accept-Encoding from requests to /wp-admin/, /wp-login.php, /wp-json/*. The backend
-# then serves these (secret-bearing) responses uncompressed, removing the side channel. Public
-# pages and static assets keep gzip/brotli. Trade-off: ~3–10× more bytes on admin pages, which
-# is normally fine because admin traffic is low-volume. (default: ON)
+# block_breach_compression: Tag requests to BREACH-sensitive paths (/wp-admin/, /wp-login.php,
+# /wp-json/*) in the audit log so operators can verify proxy-side Accept-Encoding stripping
+# is configured. ModSecurity v2 cannot actually strip request headers (no ctl:requestHeaderRemove),
+# so the real mitigation must live in the reverse proxy (Angie/nginx: `proxy_set_header
+# Accept-Encoding "";` + `gzip off;` + `brotli off;` on those locations). (default: ON)
 #SecAction "id:9522968,phase:1,nolog,pass,t:none,setvar:tx.wphard.block_breach_compression=1"
 # block_author_archives: Block /author/<slug>/ archive pages (rule 9522122). Default OFF because
 # most blogs intentionally expose author archives. Enable only if these pages are not part of the

--- a/plugins/wordpress-hardening-files.data
+++ b/plugins/wordpress-hardening-files.data
@@ -18,7 +18,6 @@
 /wp-content/wp-rocket-config
 /wp-content/uploads/sucuri
 /wp-content/uploads/updraft
-/wp-content/backups-dup-pro
 /wp-content/index.php
 /wp-admin/install
 /wp-admin/includes
@@ -27,3 +26,6 @@
 /.wp-cli/
 /wp-cli.yml
 /wp-cli.local.yml
+# PHP per-directory config and WP debug log (defence in depth — also caught by .ini/.log regex)
+/.user.ini
+/wp-content/debug.log

--- a/tests/regression/wordpress-hardening-plugin/9522100.yaml
+++ b/tests/regression/wordpress-hardening-plugin/9522100.yaml
@@ -1,0 +1,103 @@
+---
+meta:
+  author: Thijs Eilander
+  description: wordpress-hardening-plugin
+  enabled: true
+  name: 9522100.yaml
+tests:
+  - test_title: 9522100-1
+    desc: readme.html probe is blocked in phase:1
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /readme.html
+          output:
+            log_contains: id "9522100"
+  - test_title: 9522100-2
+    desc: license.txt probe is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /license.txt
+          output:
+            log_contains: id "9522100"
+  - test_title: 9522100-3
+    desc: .user.ini probe is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /.user.ini
+          output:
+            log_contains: id "9522100"
+  - test_title: 9522100-4
+    desc: wp-admin/install.php probe is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-admin/install.php
+          output:
+            log_contains: id "9522100"
+  - test_title: 9522100-5
+    desc: wp-admin/setup-config.php probe is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-admin/setup-config.php
+          output:
+            log_contains: id "9522100"
+  - test_title: 9522100-6
+    desc: wp-includes/wlwmanifest.xml probe is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-includes/wlwmanifest.xml
+          output:
+            log_contains: id "9522100"
+  - test_title: 9522100-7
+    desc: wp-content/debug.log probe is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-content/debug.log
+          output:
+            log_contains: id "9522100"
+  - test_title: 9522100-8
+    desc: Negative — legitimate post URL containing 'license' must not match
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /blog/software-license-explained
+          output:
+            no_log_contains: id "9522100"

--- a/tests/regression/wordpress-hardening-plugin/9522112.yaml
+++ b/tests/regression/wordpress-hardening-plugin/9522112.yaml
@@ -1,0 +1,43 @@
+---
+meta:
+  author: Thijs Eilander
+  description: wordpress-hardening-plugin
+  enabled: true
+  name: 9522112.yaml
+tests:
+  - test_title: 9522112-1
+    desc: CVE-2018-6389 — long load= on load-scripts.php is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-admin/load-scripts.php?load=jquery,jquery-ui-core,jquery-ui-widget,jquery-ui-mouse,jquery-ui-sortable,wp-pointer,wp-util,wp-a11y,wp-i18n
+          output:
+            log_contains: id "9522112"
+  - test_title: 9522112-2
+    desc: CVE-2018-6389 — long load[]= array form is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-admin/load-styles.php?load[]=common,forms,admin-menu,dashboard,list-tables,edit,revisions
+          output:
+            log_contains: id "9522112"
+  - test_title: 9522112-3
+    desc: Negative — short legitimate load= must not match
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-admin/load-scripts.php?load=jquery,common
+          output:
+            no_log_contains: id "9522112"

--- a/tests/regression/wordpress-hardening-plugin/9522113.yaml
+++ b/tests/regression/wordpress-hardening-plugin/9522113.yaml
@@ -1,0 +1,79 @@
+---
+meta:
+  author: Thijs Eilander
+  description: wordpress-hardening-plugin
+  enabled: true
+  name: 9522113.yaml
+tests:
+  - test_title: 9522113-1
+    desc: .env probe is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /.env
+          output:
+            log_contains: id "9522113"
+  - test_title: 9522113-2
+    desc: .env.local probe is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /.env.local
+          output:
+            log_contains: id "9522113"
+  - test_title: 9522113-3
+    desc: .git/config probe is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /.git/config
+          output:
+            log_contains: id "9522113"
+  - test_title: 9522113-4
+    desc: .svn/entries probe is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /.svn/entries
+          output:
+            log_contains: id "9522113"
+  - test_title: 9522113-5
+    desc: .DS_Store probe is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /.DS_Store
+          output:
+            log_contains: id "9522113"
+  - test_title: 9522113-6
+    desc: Negative — legitimate URL containing 'env' must not match
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /environment/staging
+          output:
+            no_log_contains: id "9522113"

--- a/tests/regression/wordpress-hardening-plugin/9522114.yaml
+++ b/tests/regression/wordpress-hardening-plugin/9522114.yaml
@@ -1,0 +1,67 @@
+---
+meta:
+  author: Thijs Eilander
+  description: wordpress-hardening-plugin
+  enabled: true
+  name: 9522114.yaml
+tests:
+  - test_title: 9522114-1
+    desc: wp-config.php.save backup is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-config.php.save
+          output:
+            log_contains: id "9522114"
+  - test_title: 9522114-2
+    desc: wp-config.old.php (atypical placement) — only the .old after wp-config is matched
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-config.old
+          output:
+            log_contains: id "9522114"
+  - test_title: 9522114-3
+    desc: wp-config.php~ tilde backup
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-config.php~
+          output:
+            log_contains: id "9522114"
+  - test_title: 9522114-4
+    desc: wp-config.php.1 numeric backup
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-config.php.1
+          output:
+            log_contains: id "9522114"
+  - test_title: 9522114-5
+    desc: Negative — actual wp-config.php must NOT match (it's blocked elsewhere as .php deny)
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-config.php
+          output:
+            no_log_contains: id "9522114"

--- a/tests/regression/wordpress-hardening-plugin/9522115.yaml
+++ b/tests/regression/wordpress-hardening-plugin/9522115.yaml
@@ -1,0 +1,21 @@
+---
+meta:
+  author: Thijs Eilander
+  description: wordpress-hardening-plugin
+  enabled: true
+  name: 9522115.yaml
+tests:
+  - test_title: 9522115-1
+    desc: >
+      block_plugin_readme is OFF by default, so plugin readme.txt access must
+      NOT trigger 9522115 with the default config.
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-content/plugins/akismet/readme.txt
+          output:
+            no_log_contains: id "9522115"

--- a/tests/regression/wordpress-hardening-plugin/9522116.yaml
+++ b/tests/regression/wordpress-hardening-plugin/9522116.yaml
@@ -1,0 +1,71 @@
+---
+meta:
+  author: Thijs Eilander
+  description: wordpress-hardening-plugin
+  enabled: true
+  name: 9522116.yaml
+tests:
+  - test_title: 9522116-1
+    desc: php://input wrapper in query arg is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /?file=php://input
+          output:
+            log_contains: id "9522116"
+  - test_title: 9522116-2
+    desc: data:// wrapper in query arg is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /?ref=data://text/plain;base64,PD9waHAgcGhwaW5mbygpOyA/Pg==
+          output:
+            log_contains: id "9522116"
+  - test_title: 9522116-3
+    desc: phar:// wrapper in query arg is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /?x=phar:///tmp/evil.phar/payload
+          output:
+            log_contains: id "9522116"
+  - test_title: 9522116-4
+    desc: >
+      Negative — a referrer arg containing an https:// URL must NOT match.
+      The boundary anchor prevents matching 'php://' inside 'https://'.
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /?ref=https://example.com/page
+          output:
+            no_log_contains: id "9522116"
+  - test_title: 9522116-5
+    desc: >
+      Negative — a query arg literally named 'phpfile' must NOT match,
+      since ARGS_NAMES is no longer in the target list.
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /?phpfile=index
+          output:
+            no_log_contains: id "9522116"

--- a/tests/regression/wordpress-hardening-plugin/9522117.yaml
+++ b/tests/regression/wordpress-hardening-plugin/9522117.yaml
@@ -1,0 +1,35 @@
+---
+meta:
+  author: Thijs Eilander
+  description: wordpress-hardening-plugin
+  enabled: true
+  name: 9522117.yaml
+tests:
+  - test_title: 9522117-1
+    desc: SureTriggers /wp-json route probe is blocked (CVE-2025-3102)
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: POST
+            uri: /wp-json/sure-triggers/v1/connection/create-wp-connection
+            data: |
+              {"client_id":"x"}
+          output:
+            log_contains: id "9522117"
+  - test_title: 9522117-2
+    desc: SureTriggers via index.php?rest_route alternate path is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: POST
+            uri: /index.php?rest_route=/sure-triggers/v1/connection/create-wp-connection
+            data: |
+              {}
+          output:
+            log_contains: id "9522117"

--- a/tests/regression/wordpress-hardening-plugin/9522118.yaml
+++ b/tests/regression/wordpress-hardening-plugin/9522118.yaml
@@ -1,0 +1,35 @@
+---
+meta:
+  author: Thijs Eilander
+  description: wordpress-hardening-plugin
+  enabled: true
+  name: 9522118.yaml
+tests:
+  - test_title: 9522118-1
+    desc: Bricks Builder render_element probe is blocked (CVE-2024-25600)
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: POST
+            uri: /wp-json/bricks/v1/render_element
+            data: |
+              {"element":{"name":"code"}}
+          output:
+            log_contains: id "9522118"
+  - test_title: 9522118-2
+    desc: Bricks Builder via index.php?rest_route alternate path is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: POST
+            uri: /index.php?rest_route=/bricks/v1/render_element
+            data: |
+              {}
+          output:
+            log_contains: id "9522118"

--- a/tests/regression/wordpress-hardening-plugin/9522119.yaml
+++ b/tests/regression/wordpress-hardening-plugin/9522119.yaml
@@ -1,0 +1,67 @@
+---
+meta:
+  author: Thijs Eilander
+  description: wordpress-hardening-plugin
+  enabled: true
+  name: 9522119.yaml
+tests:
+  - test_title: 9522119-1
+    desc: TRACE method on /wp-login.php is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: TRACE
+            uri: /wp-login.php
+          output:
+            log_contains: id "9522119"
+  - test_title: 9522119-2
+    desc: PROPFIND method on /wp-admin/ is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: PROPFIND
+            uri: /wp-admin/
+          output:
+            log_contains: id "9522119"
+  - test_title: 9522119-3
+    desc: PUT method on /xmlrpc.php is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: PUT
+            uri: /xmlrpc.php
+          output:
+            log_contains: id "9522119"
+  - test_title: 9522119-4
+    desc: Negative — GET on /wp-login.php is allowed
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-login.php
+          output:
+            no_log_contains: id "9522119"
+  - test_title: 9522119-5
+    desc: Negative — TRACE on a public page is NOT blocked by this rule
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: TRACE
+            uri: /about
+          output:
+            no_log_contains: id "9522119"

--- a/tests/regression/wordpress-hardening-plugin/9522120.yaml
+++ b/tests/regression/wordpress-hardening-plugin/9522120.yaml
@@ -1,0 +1,55 @@
+---
+meta:
+  author: Thijs Eilander
+  description: wordpress-hardening-plugin
+  enabled: true
+  name: 9522120.yaml
+tests:
+  - test_title: 9522120-1
+    desc: revslider_show_image legacy probe is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-admin/admin-ajax.php?action=revslider_show_image&img=../wp-config.php
+          output:
+            log_contains: id "9522120"
+  - test_title: 9522120-2
+    desc: timthumb.php legacy probe is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-content/themes/sometheme/scripts/timthumb.php
+          output:
+            log_contains: id "9522120"
+  - test_title: 9522120-3
+    desc: wp-file-manager connector.minimal.php legacy probe is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /wp-content/plugins/wp-file-manager/lib/php/connector.minimal.php
+          output:
+            log_contains: id "9522120"
+  - test_title: 9522120-4
+    desc: Duplicator installer-backup.php legacy probe is blocked
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /installer-backup.php
+          output:
+            log_contains: id "9522120"

--- a/tests/regression/wordpress-hardening-plugin/9522121.yaml
+++ b/tests/regression/wordpress-hardening-plugin/9522121.yaml
@@ -1,0 +1,67 @@
+---
+meta:
+  author: Thijs Eilander
+  description: wordpress-hardening-plugin
+  enabled: true
+  name: 9522121.yaml
+tests:
+  - test_title: 9522121-1
+    desc: BREACH mitigation fires on /wp-admin/ (Accept-Encoding gets stripped)
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept-Encoding: gzip, deflate, br
+            port: 80
+            method: GET
+            uri: /wp-admin/
+          output:
+            log_contains: id "9522121"
+  - test_title: 9522121-2
+    desc: BREACH mitigation fires on /wp-login.php
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept-Encoding: gzip
+            port: 80
+            method: GET
+            uri: /wp-login.php
+          output:
+            log_contains: id "9522121"
+  - test_title: 9522121-3
+    desc: BREACH mitigation fires on /wp-json/
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept-Encoding: gzip
+            port: 80
+            method: GET
+            uri: /wp-json/wp/v2/posts
+          output:
+            log_contains: id "9522121"
+  - test_title: 9522121-4
+    desc: Negative — public page keeps Accept-Encoding (rule does not fire)
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept-Encoding: gzip
+            port: 80
+            method: GET
+            uri: /about-us
+          output:
+            no_log_contains: id "9522121"

--- a/tests/regression/wordpress-hardening-plugin/9522122.yaml
+++ b/tests/regression/wordpress-hardening-plugin/9522122.yaml
@@ -1,0 +1,22 @@
+---
+meta:
+  author: Thijs Eilander
+  description: wordpress-hardening-plugin
+  enabled: true
+  name: 9522122.yaml
+tests:
+  - test_title: 9522122-1
+    desc: >
+      block_author_archives is OFF by default — /author/john-doe must NOT
+      trigger 9522122 with default configuration. Most blogs want author
+      archives publicly reachable.
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers: {Host: localhost, User-Agent: OWASP CRS}
+            port: 80
+            method: GET
+            uri: /author/john-doe/
+          output:
+            no_log_contains: id "9522122"

--- a/tests/regression/wordpress-hardening-plugin/9522701.yaml
+++ b/tests/regression/wordpress-hardening-plugin/9522701.yaml
@@ -1,0 +1,14 @@
+---
+# Rules 9522701, 9522702, 9522703 are phase:3 response-header strippers that
+# fire when the upstream backend emits X-Pingback / X-Powered-By (matching
+# wordpress|php) / Link (matching api.w.org). They cannot be exercised by
+# ftw-style request-only tests because the framework's backend does not emit
+# those headers. Verification is operational: deploy the rules, hit /wp-login.php
+# on a real WordPress install, and confirm the response no longer contains
+# X-Pingback or the api.w.org Link header.
+meta:
+  author: Thijs Eilander
+  description: wordpress-hardening-plugin
+  enabled: false
+  name: 9522701.yaml
+tests: []


### PR DESCRIPTION
## Summary

- **13 new toggles / rules** (9522100, 9522112–9522122, 9522701–9522703): info-leak hard-block, CVE-2018-6389 DoS, VCS/dotfile paths, wp-config backups, plugin-readme probes, PHP stream wrappers, SureTriggers + Bricks Builder CVEs, uncommon-method block, legacy-CVE noise reduction, BREACH detection marker, optional /author/ archive block, X-Pingback/X-Powered-By/api.w.org Link detection.
- **ID-collision purge**: all config.conf example SecAction IDs and README enable examples moved to reserved 9522900+ range. Previously, uncommenting any of them would have produced a duplicate-id parse error.
- **Several bug fixes** flagged in the audit: /author/ archive blocking now opt-in, ARGS:pwd dropped from block_admin_login, ARGS_NAMES dropped from block_php_wrappers (https:// false-positive), dead ratelimit_login_window variable removed, block_dangerous_admin narrowed (no overlap with 9522100).
- **13 regression-test YAMLs** covering every new rule with positive and negative cases.

## Test plan

- [x] `scripts/ci-local.sh` passes (rule-ID dedupe, pmFromFile, secrules-parsing syntax, gate markers, regression-YAML parse)
- [ ] CI workflow runs `tests/regression/*.yaml` against a live ModSec instance — verify all 13 new YAMLs pass
- [ ] Deploy to staging; confirm BREACH-sensitive paths are tagged in audit log and that proxy-side `proxy_set_header Accept-Encoding ""` is actually configured (the rule is now detection-only — the strip must live in Angie config)
- [ ] Verify response-header detection rules 9522701/9522702/9522703 log on real WP responses; pair with `proxy_hide_header` directives in Angie
- [ ] Manually test that `?author=1` (numeric) still blocks (9522104) but `/author/john-doe/` does NOT block by default (9522122 OFF)