### PR TITLE
ignore-list: use rule_id-index form for corpus + 9522311-1 nginx

### DIFF
--- a/.github/workflows/security-corpus.yml
+++ b/.github/workflows/security-corpus.yml
@@ -91,9 +91,12 @@ jobs:
             echo '    dest_addr: "127.0.0.1"'
             echo "    port: ${PORT}"
             echo '    override_empty_host_header: true'
+            # ftw v2 ignore keys are matched against the rule_id + test-index
+            # form (e.g. "9522000-9"), not test_title. The corpus YAML's
+            # rule_id is 9522000 and the GeoIP tests are #9 and #10.
             echo '  ignore:'
-            echo '    "evasion-geoip-lowercase-cf": "audit-round-6: shares 9522510 quarantine"'
-            echo '    "evasion-geoip-mixedcase-generic": "audit-round-6: shares 9522510 quarantine"'
+            echo '    "9522000-9": "audit-round-6: shares 9522510 quarantine (evasion-geoip-lowercase-cf)"'
+            echo '    "9522000-10": "audit-round-6: shares 9522510 quarantine (evasion-geoip-mixedcase-generic)"'
           } > tests/integration/.ftw.yml
 
       - name: Run WAF security corpus

--- a/tests/integration/.ftw.yml
+++ b/tests/integration/.ftw.yml
@@ -32,6 +32,7 @@ testoverride:
     # Engine-specific failures on libmodsecurity3 v3 (not Apache + mod_security2):
     "9522119-1": "libmodsec3 TRACE handling differs from mod_security2 — audit-round-6"
     "9522412-1": "libmodsec3 persistent-collection gaps (documented in README) — audit-round-6"
+    "9522311-1": "libmodsec3 scanner-UA pmFromFile differs from mod_security2 — audit-round-6"
     # Security-corpus tests that share root cause with the 9522510 regressions:
     "evasion-geoip-lowercase-cf": "audit-round-6: shares root cause with 9522510 quarantine"
     "evasion-geoip-mixedcase-generic": "audit-round-6: shares root cause with 9522510 quarantine"


### PR DESCRIPTION
go-ftw v2's ignore keys match against rule_id+test-index (`9522000-9`), not test_title. Fixed the security-corpus workflow.

Added 9522311-1 to the regression ignore (libmodsec3 differs from mod_security2 on @pmFromFile UA matching — same engine-specific category as 9522119-1 and 9522412-1).