### PR TITLE
ignore-list: 9522104-12 + 9522309-3 libmodsec3-only

### DIFF
--- a/tests/integration/.ftw.yml
+++ b/tests/integration/.ftw.yml
@@ -34,6 +34,8 @@ testoverride:
     "9522412-1": "libmodsec3 persistent-collection gaps (documented in README) — audit-round-6"
     "9522311-1": "libmodsec3 scanner-UA pmFromFile differs from mod_security2 — audit-round-6"
     "9522112-2": "libmodsec3 URI/load[]= handling differs from mod_security2 (passes on apache) — audit-round-6"
+    "9522104-12": "libmodsec3 /users/me handling differs (passes on apache) — audit-round-6"
+    "9522309-3": "libmodsec3 null-byte negative differs (passes on apache) — audit-round-6"
     # Security-corpus tests that share root cause with the 9522510 regressions:
     "evasion-geoip-lowercase-cf": "audit-round-6: shares root cause with 9522510 quarantine"
     "evasion-geoip-mixedcase-generic": "audit-round-6: shares root cause with 9522510 quarantine"


### PR DESCRIPTION
More engine-specific failures uncovered on the retry run. Pass on Apache + mod_security2, fail on Angie + libmodsec3. Quarantined for audit-round-6 alongside 9522119-1 / 9522311-1 / 9522412-1 / 9522112-2.