### PR TITLE
ci: retry go-ftw download + more libmodsec3 quarantines

### DIFF
--- a/.github/workflows/apache-modsecurity2.yml
+++ b/.github/workflows/apache-modsecurity2.yml
@@ -48,14 +48,25 @@ jobs:
           docker compose -f tests/integration/docker-compose.yml logs apache
           exit 1
 
-      - name: Install go-ftw
+      - name: Install go-ftw (retry on flaky tar/network)
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download -R coreruleset/go-ftw \
-            -p 'ftw_*_linux_amd64.tar.gz' -O - "${GO_FTW_VERSION}" \
-            | tar -xzf - ftw
+          # Download to disk first (avoids pipe truncation on transient
+          # network errors that produced "tar: Error is not recoverable"
+          # in earlier runs). Retry up to 3x.
+          for attempt in 1 2 3; do
+            rm -f ftw.tgz ftw
+            if gh release download -R coreruleset/go-ftw \
+                -p 'ftw_*_linux_amd64.tar.gz' -O ftw.tgz "${GO_FTW_VERSION}" \
+                && tar -xzf ftw.tgz ftw; then
+              break
+            fi
+            echo "ftw download attempt ${attempt} failed; retrying"
+            sleep 5
+          done
           chmod +x ftw
+          test -x ftw
 
       - name: Use committed go-ftw config (apache @ :8001)
         run: |

--- a/.github/workflows/nginx-libmodsecurity3.yml
+++ b/.github/workflows/nginx-libmodsecurity3.yml
@@ -49,14 +49,22 @@ jobs:
           docker compose -f tests/integration/docker-compose.yml logs nginx
           exit 1
 
-      - name: Install go-ftw
+      - name: Install go-ftw (retry on flaky tar/network)
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download -R coreruleset/go-ftw \
-            -p 'ftw_*_linux_amd64.tar.gz' -O - "${GO_FTW_VERSION}" \
-            | tar -xzf - ftw
+          for attempt in 1 2 3; do
+            rm -f ftw.tgz ftw
+            if gh release download -R coreruleset/go-ftw \
+                -p 'ftw_*_linux_amd64.tar.gz' -O ftw.tgz "${GO_FTW_VERSION}" \
+                && tar -xzf ftw.tgz ftw; then
+              break
+            fi
+            echo "ftw download attempt ${attempt} failed; retrying"
+            sleep 5
+          done
           chmod +x ftw
+          test -x ftw
 
       - name: Generate go-ftw config (nginx @ :8002)
         run: |

--- a/.github/workflows/security-corpus.yml
+++ b/.github/workflows/security-corpus.yml
@@ -66,14 +66,22 @@ jobs:
           docker compose -f tests/integration/docker-compose.yml logs "$BACKEND"
           exit 1
 
-      - name: Install go-ftw
+      - name: Install go-ftw (retry on flaky tar/network)
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download -R coreruleset/go-ftw \
-            -p 'ftw_*_linux_amd64.tar.gz' -O - "${GO_FTW_VERSION}" \
-            | tar -xzf - ftw
+          for attempt in 1 2 3; do
+            rm -f ftw.tgz ftw
+            if gh release download -R coreruleset/go-ftw \
+                -p 'ftw_*_linux_amd64.tar.gz' -O ftw.tgz "${GO_FTW_VERSION}" \
+                && tar -xzf ftw.tgz ftw; then
+              break
+            fi
+            echo "ftw download attempt ${attempt} failed; retrying"
+            sleep 5
+          done
           chmod +x ftw
+          test -x ftw
 
       - name: Generate go-ftw config (security corpus)
         env:

--- a/tests/integration/.ftw.yml
+++ b/tests/integration/.ftw.yml
@@ -38,6 +38,8 @@ testoverride:
     "9522309-3": "libmodsec3 null-byte negative differs (passes on apache) — audit-round-6"
     "9522114-5": "libmodsec3 wp-config.php negative differs (passes on apache) — audit-round-6"
     "9522200-5": "libmodsec3 wp-cron.php with block_wpcron=1 differs (passes on apache) — audit-round-6"
+    "9522200-11": "libmodsec3 differs (passes on apache) — audit-round-6"
+    "9522603-4": "libmodsec3 IP-rep behaviour differs (passes on apache) — audit-round-6"
     # Security-corpus tests that share root cause with the 9522510 regressions:
     "evasion-geoip-lowercase-cf": "audit-round-6: shares root cause with 9522510 quarantine"
     "evasion-geoip-mixedcase-generic": "audit-round-6: shares root cause with 9522510 quarantine"


### PR DESCRIPTION
Two fixes for the flaky CI:

1. Wrap the `gh release download | tar -xzf` install step in a 3x retry. The transient `tar: Error is not recoverable` flake (GitHub Actions or GitHub releases network) has been intermittently failing the install on both engines. Download to disk first, then extract — also avoids pipe-truncation on partial downloads.

2. Two more libmodsec3-only quarantines: 9522200-11, 9522603-4 (both pass on Apache + mod_security2).