### PR TITLE
rules: drop accuracy action for Coraza compatibility

### DIFF
--- a/plugins/wordpress-hardening-after.conf
+++ b/plugins/wordpress-hardening-after.conf
@@ -52,7 +52,6 @@ SecRule TX:wphard.block_info_leak_files "@eq 1" \
   tag:'wordpress',\
   tag:'info-leak',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'wordpress-hardening-plugin/1.2.0',\
@@ -81,7 +80,6 @@ SecRule TX:wphard.block_load_scripts_dos "@eq 1" \
   tag:'cve-2018-6389',\
   tag:'dos',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'WARNING',\
   ver:'wordpress-hardening-plugin/1.2.0',\
@@ -106,7 +104,6 @@ SecRule TX:wphard.block_vcs_paths "@eq 1" \
   tag:'info-leak',\
   tag:'vcs-metadata',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'wordpress-hardening-plugin/1.2.0',\
@@ -132,7 +129,6 @@ SecRule TX:wphard.block_wpconfig_backups "@eq 1" \
   tag:'info-leak',\
   tag:'config-leak',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'CRITICAL',\
   ver:'wordpress-hardening-plugin/1.2.0',\
@@ -159,7 +155,6 @@ SecRule TX:wphard.block_plugin_readme "@eq 1" \
   tag:'info-leak',\
   tag:'version-disclosure',\
   tag:'paranoia-level/2',\
-  accuracy:'8',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'wordpress-hardening-plugin/1.2.0',\
@@ -184,7 +179,6 @@ SecRule TX:wphard.block_uncommon_methods "@eq 1" \
   tag:'wordpress',\
   tag:'http-method',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'WARNING',\
   ver:'wordpress-hardening-plugin/1.2.0',\
@@ -216,7 +210,6 @@ SecRule TX:wphard.block_legacy_cves "@eq 1" \
   tag:'wordpress',\
   tag:'legacy-cve',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'wordpress-hardening-plugin/1.2.0',\

--- a/plugins/wordpress-hardening-before.conf
+++ b/plugins/wordpress-hardening-before.conf
@@ -500,7 +500,6 @@ SecRule TX:wphard.block_php_wrappers "@eq 1" \
   tag:'lfi-rfi',\
   tag:'php-wrappers',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'CRITICAL',\
   ver:'wordpress-hardening-plugin/1.2.0',\
@@ -531,7 +530,6 @@ SecRule TX:wphard.block_known_plugin_cves "@eq 1" \
   tag:'known-cve',\
   tag:'suretriggers',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'CRITICAL',\
   ver:'WPHARD/1.0.0',\
@@ -550,7 +548,6 @@ SecRule TX:wphard.block_known_plugin_cves "@eq 1" \
   tag:'known-cve',\
   tag:'bricks-builder',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'CRITICAL',\
   ver:'WPHARD/1.0.0',\
@@ -643,7 +640,6 @@ SecRule REQUEST_FILENAME "^/xmlrpc\.php" \
   tag:'wordpress',\
   tag:'xmlrpc',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'WPHARD/1.1.0',\
@@ -685,7 +681,6 @@ SecRule REQUEST_URI "@rx (?:[/?&]author=[0-9]+)|(?:/wp/v2/users/?(?:\?|$))|(?:/w
   tag:'wordpress',\
   tag:'enumeration',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'WPHARD/1.1.0',\
@@ -713,7 +708,6 @@ SecRule TX:wphard.block_author_archives "@eq 1" \
   tag:'enumeration',\
   tag:'author-archive',\
   tag:'paranoia-level/2',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'WPHARD/1.0.0',\
@@ -751,7 +745,6 @@ SecRule REQUEST_FILENAME "@rx ^/wp-json/.+" \
   tag:'rest-api',\
   tag:'wp-json',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'WPHARD/1.1.0',\
@@ -780,7 +773,6 @@ SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
   tag:'wordpress',\
   tag:'admin-login',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'WARNING',\
   ver:'WPHARD/1.1.0',\
@@ -822,7 +814,6 @@ SecRule REQUEST_FILENAME "^/wp-cron\.php" \
   tag:'wordpress',\
   tag:'wpcron',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'WPHARD/1.1.0',\
@@ -871,7 +862,6 @@ SecRule REQUEST_FILENAME "@rx \.php$" \
   tag:'wordpress',\
   tag:'direct-access',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'WPHARD/1.1.0',\
@@ -892,7 +882,6 @@ SecRule REQUEST_FILENAME "@pmFromFile wordpress-hardening-files.data" \
   tag:'wordpress',\
   tag:'direct-access',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'WPHARD/1.1.0',\
@@ -920,7 +909,6 @@ SecRule REQUEST_FILENAME "@rx \.(?:pl|cgi|py|sh|lua|aspx?)$" \
   tag:'wordpress',\
   tag:'only-allow-php-extension',\
   tag:'paranoia-level/2',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'WPHARD/1.1.0',\
@@ -940,7 +928,6 @@ SecRule REQUEST_FILENAME "@rx ^/wp-content/uploads/.*\.(?:s?html?|swf|lua)$" \
   tag:'wordpress',\
   tag:'uploads',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'WPHARD/1.1.0',\
@@ -958,7 +945,6 @@ SecRule REQUEST_FILENAME "@rx \.(?:conf|htaccess|htpass|sql|orig|bak|db|ini|md|l
   tag:'wordpress',\
   tag:'sensitive-files',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'WPHARD/1.1.0',\
@@ -989,7 +975,6 @@ SecRule REQUEST_FILENAME "@rx ^/wp-json/?$" \
   tag:'sensitive-files',\
   tag:'wp-json',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'WPHARD/1.1.0',\
@@ -1019,7 +1004,6 @@ SecRule REQUEST_FILENAME "@rx ^/wp-admin/(theme|plugin)-editor\.php" \
   tag:'wordpress',\
   tag:'editor-access',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'WPHARD/1.1.0',\
@@ -1054,7 +1038,6 @@ SecRule REQUEST_FILENAME "@rx ^/(?:backups?|db-backup|site-backup|wordpress-back
   tag:'wordpress',\
   tag:'backup-files',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'WPHARD/1.1.0',\
@@ -1084,7 +1067,6 @@ SecRule REQUEST_FILENAME "@rx (?:\.(?:sql\.gz|sql\.bz2|sql\.zip|dump\.sql)|(?:^|
   tag:'wordpress',\
   tag:'database-files',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'WPHARD/1.1.0',\
@@ -1120,7 +1102,6 @@ SecRule REQUEST_URI "@rx /wp-content/uploads/[^?]*\.\." \
   tag:'wordpress',\
   tag:'upload-traversal',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'WPHARD/1.1.0',\
@@ -1164,7 +1145,6 @@ SecRule REQUEST_URI|ARGS_NAMES|ARGS "@rx %00|%u0000|\x00" \
   tag:'wordpress',\
   tag:'null-byte',\
   tag:'paranoia-level/2',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'CRITICAL',\
   ver:'WPHARD/1.1.0',\
@@ -1202,7 +1182,6 @@ SecRule REQUEST_HEADERS:User-Agent "@pmFromFile wordpress-hardening-scanners.dat
   tag:'wordpress',\
   tag:'scanner',\
   tag:'paranoia-level/2',\
-  accuracy:'7',\
   maturity:'1',\
   severity:'WARNING',\
   ver:'WPHARD/1.1.0',\
@@ -1240,7 +1219,6 @@ SecRule REQUEST_URI|ARGS_NAMES "@rx (?:xdebug_session(?:_(?:start|stop))?|xdebug
   tag:'wordpress',\
   tag:'debug-probe',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'WPHARD/1.1.0',\
@@ -1270,7 +1248,6 @@ SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
   tag:'wordpress',\
   tag:'login-injection',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'CRITICAL',\
   ver:'WPHARD/1.1.0',\
@@ -1315,7 +1292,6 @@ SecRule TX:wphard.block_orderby_injection "@eq 1" \
   tag:'attack-sqli',\
   tag:'order-by-injection',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'CRITICAL',\
   ver:'wordpress-hardening-plugin/1.2.0',\
@@ -1339,7 +1315,6 @@ SecRule TX:wphard.block_orderby_injection "@eq 1" \
   tag:'attack-sqli',\
   tag:'order-by-injection',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'CRITICAL',\
   ver:'wordpress-hardening-plugin/1.2.0',\
@@ -1362,7 +1337,6 @@ SecRule TX:wphard.block_orderby_injection "@eq 1" \
   tag:'attack-sqli',\
   tag:'order-by-injection',\
   tag:'paranoia-level/2',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'CRITICAL',\
   ver:'wordpress-hardening-plugin/1.2.0',\
@@ -1389,7 +1363,6 @@ SecRule TX:wphard.block_numeric_param_injection "@eq 1" \
   tag:'attack-sqli',\
   tag:'attack-xss',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'CRITICAL',\
   ver:'wordpress-hardening-plugin/1.2.0',\
@@ -1413,7 +1386,6 @@ SecRule TX:wphard.strict_integer_params "@eq 1" \
   tag:'attack-sqli',\
   tag:'attack-xss',\
   tag:'paranoia-level/2',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'CRITICAL',\
   ver:'wordpress-hardening-plugin/1.2.0',\
@@ -1454,7 +1426,6 @@ SecRule REQUEST_FILENAME "@rx ^/wp-admin/(upgrade|wp-activate)\.php" \
   tag:'wordpress',\
   tag:'dangerous-admin',\
   tag:'paranoia-level/2',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'NOTICE',\
   ver:'WPHARD/1.1.0',\
@@ -1571,7 +1542,6 @@ SecRule IP:login_attempts "@ge %{tx.wphard.ratelimit_login_attempts}" \
   tag:'wordpress',\
   tag:'rate-limit',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'WARNING',\
   ver:'WPHARD/1.1.0',\
@@ -1649,7 +1619,6 @@ SecRule TX:wphard.geoip_country "@rx ^[A-Za-z]{2}$" \
   tag:'wordpress',\
   tag:'geoip',\
   tag:'paranoia-level/1',\
-  accuracy:'9',\
   maturity:'1',\
   severity:'WARNING',\
   ver:'WPHARD/1.1.0',\
@@ -1702,7 +1671,6 @@ SecRule TX:wphard.client_ip "@ipMatchFromFile wordpress-hardening-ip-reputation.
   tag:'wordpress',\
   tag:'ip-reputation',\
   tag:'paranoia-level/1',\
-  accuracy:'8',\
   maturity:'1',\
   severity:'CRITICAL',\
   ver:'WPHARD/1.1.0',\


### PR DESCRIPTION
## Problem

Coraza WAF does not implement the `accuracy` metadata action and aborts config load:

```
failed to compile the directive "secrule": invalid action "accuracy"
```

Reported in #30 (also reproducible in the Coraza playground).

## Fix

Removed all **39** `accuracy:'N'` occurrences (`before.conf` ×32, `after.conf` ×7). `accuracy` is informational metadata only — no effect on matching, severity, or anomaly scoring — so ModSecurity behaviour is unchanged. Mirrors OWASP CRS, which also omits `accuracy`.

## Compatibility audit

Checked every other action / operator / transformation / ctl in the rule set against Coraza's `internal/actions` + operator/transformation sets — `accuracy` was the **only** unsupported token. Notably the sibling `maturity` action **is** implemented by Coraza (`maturity.go`) and is kept.

`scripts/ci-local.sh` passes (secrules-parsing syntax OK, all gate/marker/regression checks green).

Fixes #30