### PR TITLE
ci: run on self-hosted builder02 runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  labels:
+    - builder02
+    - lxc
+    - docker

--- a/.github/workflows/apache-modsecurity2.yml
+++ b/.github/workflows/apache-modsecurity2.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   apache-modsecurity2:
     name: Apache + ModSecurity v2
-    runs-on: [self-hosted, builder02, lxc]
+    runs-on: [self-hosted, builder02, docker]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/apache-modsecurity2.yml
+++ b/.github/workflows/apache-modsecurity2.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   apache-modsecurity2:
     name: Apache + ModSecurity v2
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, builder02, lxc]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,7 @@ name: Integration tests
 jobs:
   validate-gates:
     name: Validate Gate Variables
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, builder02, lxc]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]        # yamllint disable-line rule:truthy
 jobs:
   validate-files:
     name: Validate Plugin Files
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, builder02, lxc]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/nginx-libmodsecurity3.yml
+++ b/.github/workflows/nginx-libmodsecurity3.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   nginx-libmodsecurity3:
     name: nginx + libmodsecurity3
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, builder02, lxc]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/nginx-libmodsecurity3.yml
+++ b/.github/workflows/nginx-libmodsecurity3.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   nginx-libmodsecurity3:
     name: nginx + libmodsecurity3
-    runs-on: [self-hosted, builder02, lxc]
+    runs-on: [self-hosted, builder02, docker]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/security-corpus.yml
+++ b/.github/workflows/security-corpus.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   security-corpus:
     name: "Corpus — ModSecurity v2"
-    runs-on: [self-hosted, builder02, lxc]
+    runs-on: [self-hosted, builder02, docker]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/security-corpus.yml
+++ b/.github/workflows/security-corpus.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   security-corpus:
     name: "Corpus — ModSecurity v2"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, builder02, lxc]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Moves `ubuntu-latest` jobs to the myguard-labs org self-hosted runner pool (builder02 incus LXC). Adds `.github/actionlint.yaml` for the custom labels. Windows/arm legs stay GitHub-hosted.