### PR TITLE
ci: pin action SHAs, harden workflow hygiene

### DIFF
--- a/.github/workflows/apache-modsecurity2.yml
+++ b/.github/workflows/apache-modsecurity2.yml
@@ -13,6 +13,10 @@
 on: [push, pull_request]          # yamllint disable-line rule:truthy
 name: Apache + ModSecurity v2
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -28,7 +32,9 @@ jobs:
     name: Apache + ModSecurity v2
     runs-on: [self-hosted, builder02, docker]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Prepare log dir
         run: |
@@ -51,7 +57,7 @@ jobs:
       - name: Start Apache CRS stack
         run: |
           docker compose -f tests/integration/docker-compose.yml up -d apache
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if curl -fsS -o /dev/null "http://127.0.0.1:8001/"; then
               echo "apache up"; exit 0
             fi

--- a/.github/workflows/coraza.yml
+++ b/.github/workflows/coraza.yml
@@ -13,6 +13,10 @@
 on: [pull_request]                # yamllint disable-line rule:truthy
 name: Coraza compatibility
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -22,9 +26,11 @@ jobs:
     runs-on: [self-hosted, builder02, lxc]
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: stable
           cache-dependency-path: tests/coraza/go.sum

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,12 +2,21 @@
 on: [push, pull_request]          # yamllint disable-line rule:truthy
 name: Integration tests
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   validate-gates:
     name: Validate Gate Variables
     runs-on: [self-hosted, builder02, lxc]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Verify REST API gate coverage
         run: |
@@ -115,12 +124,12 @@ jobs:
           # and renamed markers.
           echo "Checking skipAfter targets resolve to a SecMarker..."
           MISSING=0
-          for label in $(grep -ohE 'skipAfter:[A-Za-z0-9_]+' plugins/*.conf | cut -d: -f2 | sort -u); do
+          while read -r label; do
             if ! grep -qE "SecMarker \"?${label}\"?" plugins/*.conf; then
               echo "ERROR: skipAfter:${label} has no matching SecMarker"
               MISSING=1
             fi
-          done
+          done < <(grep -ohE 'skipAfter:[A-Za-z0-9_]+' plugins/*.conf | cut -d: -f2 | sort -u)
           [ "$MISSING" -eq 0 ] && echo "✓ All skipAfter targets resolve"
           [ "$MISSING" -eq 0 ] || exit 1
 
@@ -153,18 +162,18 @@ jobs:
           # per-feature checks so new gates/skip-targets are covered too.
           echo "Checking markers are well-formed and reachable..."
           BAD=0
-          for end in $(grep -ohE 'SecMarker "END_[A-Z0-9_]+"' plugins/*.conf | sed 's/SecMarker "//;s/"//'); do
+          while read -r end; do
             begin="BEGIN_${end#END_}"
             if ! grep -qE "SecMarker \"${begin}\"" plugins/*.conf; then
               # skip-only target is allowed, but must be jumped to
               grep -qE "skipAfter:${end}\b" plugins/*.conf || { echo "ERROR: ${end} has no BEGIN_ and no skipAfter targets it (dead marker)"; BAD=1; }
             fi
             grep -qE "skipAfter:${end}\b" plugins/*.conf || { echo "ERROR: ${end} is never targeted by a skipAfter (dead gate)"; BAD=1; }
-          done
-          for begin in $(grep -ohE 'SecMarker "BEGIN_[A-Z0-9_]+"' plugins/*.conf | sed 's/SecMarker "//;s/"//'); do
+          done < <(grep -ohE 'SecMarker "END_[A-Z0-9_]+"' plugins/*.conf | sed 's/SecMarker "//;s/"//')
+          while read -r begin; do
             end="END_${begin#BEGIN_}"
             grep -qE "SecMarker \"${end}\"" plugins/*.conf || { echo "ERROR: ${begin} has no matching ${end}"; BAD=1; }
-          done
+          done < <(grep -ohE 'SecMarker "BEGIN_[A-Z0-9_]+"' plugins/*.conf | sed 's/SecMarker "//;s/"//')
           [ "$BAD" -eq 0 ] && echo "✓ All markers well-formed and reachable"
           [ "$BAD" -eq 0 ] || exit 1
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           # Validate that all @pmFromFile references point to existing .data files
           grep -r "@pmFromFile" plugins/*.conf | while read -r line; do
-            file=$(echo "$line" | sed -n 's/.*@pmFromFile \([^ ]*\).*/\1/p')
+            file=$(echo "$line" | sed -n 's/.*@pmFromFile "\?\([^ "]*\).*/\1/p')
             if [ -n "$file" ]; then
               if [ ! -f "plugins/$file" ]; then
                 echo "ERROR: Referenced file not found: $file"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,18 +1,27 @@
 ---
 on: [push, pull_request]        # yamllint disable-line rule:truthy
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   validate-files:
     name: Validate Plugin Files
     runs-on: [self-hosted, builder02, lxc]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Check @pmFromFile references
         run: |
           # Validate that all @pmFromFile references point to existing .data files
-          grep -r "@pmFromFile" plugins/*.conf | while read line; do
-            file=$(echo $line | sed -n 's/.*@pmFromFile \([^ ]*\).*/\1/p')
+          grep -r "@pmFromFile" plugins/*.conf | while read -r line; do
+            file=$(echo "$line" | sed -n 's/.*@pmFromFile \([^ ]*\).*/\1/p')
             if [ -n "$file" ]; then
               if [ ! -f "plugins/$file" ]; then
                 echo "ERROR: Referenced file not found: $file"
@@ -25,8 +34,8 @@ jobs:
       - name: Check Rule ID ranges
         run: |
           # Validate that all rules are in the allocated range 9522000-9522999
-          grep -o 'id:[0-9]*' plugins/*.conf | cut -d: -f2 | while read id; do
-            if [ $id -lt 9522000 ] || [ $id -gt 9522999 ]; then
+          grep -o 'id:[0-9]*' plugins/*.conf | cut -d: -f2 | while read -r id; do
+            if [ "$id" -lt 9522000 ] || [ "$id" -gt 9522999 ]; then
               echo "ERROR: Rule ID $id outside allocated range (9522000-9522999)"
               exit 1
             fi
@@ -47,7 +56,7 @@ jobs:
         run: |
           # Check that test files reference valid rule IDs
           for testfile in tests/regression/wordpress-hardening-plugin/*.yaml; do
-            ruleid=$(basename $testfile .yaml)
+            ruleid=$(basename "$testfile" .yaml)
             # Verify this rule ID exists in config files
             if ! grep -q "id:$ruleid" plugins/*.conf; then
               echo "ERROR: Test file $testfile references non-existent rule ID $ruleid"
@@ -58,4 +67,5 @@ jobs:
 
   plugin-lint:
     needs: validate-files
-    uses: coreruleset/crs-plugin-test-action/.github/workflows/lint.yaml@main
+    # Official OWASP CRS plugin lint (pinned SHA for v3.0.0).
+    uses: coreruleset/crs-plugin-test-action/.github/workflows/lint.yaml@7e1ee6d07105ae3cb6eec95e45acb5e1a895e3d4

--- a/.github/workflows/nginx-libmodsecurity3.yml
+++ b/.github/workflows/nginx-libmodsecurity3.yml
@@ -26,6 +26,10 @@
 on: [push, pull_request]          # yamllint disable-line rule:truthy
 name: nginx + libmodsecurity3
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -38,7 +42,9 @@ jobs:
     name: nginx + libmodsecurity3
     runs-on: [self-hosted, builder02, docker]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Prepare log dir
         run: |
@@ -64,7 +70,7 @@ jobs:
           # load it at startup and nginx never serves — the wait below times
           # out and the job fails. That is the parse/load gate.
           docker compose -f tests/integration/docker-compose.yml up -d nginx
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if curl -fsS -o /dev/null "http://127.0.0.1:8002/"; then
               echo "nginx up — all rules parsed and loaded on libmodsecurity3"
               exit 0

--- a/.github/workflows/security-corpus.yml
+++ b/.github/workflows/security-corpus.yml
@@ -15,6 +15,10 @@
 on: [push, pull_request]          # yamllint disable-line rule:truthy
 name: WAF security corpus
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -29,7 +33,9 @@ jobs:
     name: "Corpus — ModSecurity v2"
     runs-on: [self-hosted, builder02, docker]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Prepare log dir
         run: |
@@ -51,7 +57,7 @@ jobs:
       - name: Start Apache CRS stack
         run: |
           docker compose -f tests/integration/docker-compose.yml up -d apache
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if curl -fsS -o /dev/null "http://127.0.0.1:8001/"; then
               echo "apache up"; exit 0
             fi


### PR DESCRIPTION
Deploys the CI-hygiene fixes from vimbadmin-crs-plugin (6715937) and vaultwarden-crs-plugin (ef3364f).

- Pin `actions/checkout` (v4.2.2, was mixed v3/v4), `actions/setup-go` (v5), `crs-plugin-test-action` (v3.0.0, was `@main`) to SHAs; add `persist-credentials: false`
- Add top-level `permissions: contents: read` to integration.yml + lint.yml
- lint.yml shellcheck SC2086/SC2162; SC2034 `for i`->`for _`; SC2013 `for x in $(grep)`->`while read`
- `concurrency` group + cancel-in-progress on all 6 workflows

Triggers unchanged. actionlint + zizmor clean locally.