### PR TITLE
ci: stop workflows running twice on PRs

### DIFF
--- a/.github/workflows/apache-modsecurity2.yml
+++ b/.github/workflows/apache-modsecurity2.yml
@@ -10,7 +10,10 @@
 #
 # Security note: the only ${{ }} in a run: context is github.token; no
 # untrusted event input is interpolated anywhere.
-on: [push, pull_request]          # yamllint disable-line rule:truthy
+on:
+  push:
+    branches: [master]
+  pull_request:
 name: Apache/v2
 
 concurrency:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,8 @@
 ---
-on: [push, pull_request]          # yamllint disable-line rule:truthy
+on:
+  push:
+    branches: [master]
+  pull_request:
 name: Integration Tests
 
 concurrency:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 ---
-on: [push, pull_request]        # yamllint disable-line rule:truthy
+on:
+  push:
+    branches: [master]
+  pull_request:
 name: Lint
 
 concurrency:

--- a/.github/workflows/nginx-libmodsecurity3.yml
+++ b/.github/workflows/nginx-libmodsecurity3.yml
@@ -23,7 +23,10 @@
 #      homepage must stay clean.
 #
 # Security note: the only run:-context interpolation is github.token.
-on: [push, pull_request]          # yamllint disable-line rule:truthy
+on:
+  push:
+    branches: [master]
+  pull_request:
 name: NGINX/v3
 
 concurrency:

--- a/.github/workflows/security-corpus.yml
+++ b/.github/workflows/security-corpus.yml
@@ -12,7 +12,10 @@
 # engines, so a real bypass/over-block is caught here regardless.
 #
 # Security note: the only run:-context interpolation is github.token.
-on: [push, pull_request]          # yamllint disable-line rule:truthy
+on:
+  push:
+    branches: [master]
+  pull_request:
 name: Security Corpus
 
 concurrency:


### PR DESCRIPTION
Bare `on: [push, pull_request]` fired both the push and pull_request events for same-repo PR branches, doubling every CI run. Scoping `push` to `master` means branch pushes trigger only `pull_request`; `master` pushes (merges) still trigger `push`, so default-branch status badges stay live.