### PR TITLE
fix(rules): audit sweep — dead rate-limit window, chain-link evasion, hygiene

### DIFF
--- a/plugins/wordpress-hardening-after.conf
+++ b/plugins/wordpress-hardening-after.conf
@@ -48,7 +48,7 @@ SecRule TX:wphard.block_info_leak_files "@eq 1" \
   "id:9522100,\
   phase:1,\
   chain,\
-  t:lowercase,t:normalizePath,\
+  t:none,t:lowercase,t:normalizePath,\
   tag:'wordpress',\
   tag:'info-leak',\
   tag:'paranoia-level/1',\
@@ -59,7 +59,7 @@ SecRule TX:wphard.block_info_leak_files "@eq 1" \
   logdata:'Request URI %{REQUEST_URI}',\
   msg:'Wordpress hardening: blocked info-leak path'"
   SecRule REQUEST_URI "@rx ^/(?:readme\.html|license\.txt|\.user\.ini|wp-admin/(?:install|setup-config)\.php|wp-includes/wlwmanifest\.xml|wp-content/debug\.log)(?:$|\?)" \
-    "t:lowercase,t:normalizePath,\
+    "t:none,t:lowercase,t:normalizePath,\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # ----------------------------------------------------------------------------
@@ -75,7 +75,7 @@ SecRule TX:wphard.block_load_scripts_dos "@eq 1" \
   "id:9522112,\
   phase:1,\
   chain,\
-  t:lowercase,t:normalizePath,\
+  t:none,t:lowercase,t:normalizePath,\
   tag:'wordpress',\
   tag:'cve-2018-6389',\
   tag:'dos',\
@@ -87,7 +87,7 @@ SecRule TX:wphard.block_load_scripts_dos "@eq 1" \
   logdata:'Request URI %{REQUEST_URI}',\
   msg:'Wordpress hardening: CVE-2018-6389 load-scripts/load-styles DoS attempt'"
   SecRule REQUEST_URI "@rx ^/wp-admin/load-(?:scripts|styles)\.php\?.*\bload(?:%5B%5D|\[\])?=[^&]{80,}" \
-    "t:lowercase,t:normalizePath,\
+    "t:none,t:lowercase,t:normalizePath,\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # ----------------------------------------------------------------------------
@@ -111,7 +111,7 @@ SecRule TX:wphard.block_vcs_paths "@eq 1" \
   logdata:'Request URI %{REQUEST_URI}',\
   msg:'Wordpress hardening: blocked VCS / dotfile probe'"
   SecRule REQUEST_URI "@rx (?:^|/)(?:\.env(?:\.[a-z0-9_-]+)?|\.git(?:/[^?]*|$|ignore|attributes|modules|config|hooks)|\.svn(?:/[^?]*|$)|\.hg(?:/[^?]*|$|ignore|rc)|\.bzr(?:/[^?]*|$)|\.ds_store|\.htpasswd)(?:$|/|\?)" \
-    "t:lowercase,t:normalizePath,\
+    "t:none,t:lowercase,t:normalizePath,\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # ----------------------------------------------------------------------------
@@ -124,7 +124,7 @@ SecRule TX:wphard.block_wpconfig_backups "@eq 1" \
   "id:9522114,\
   phase:1,\
   chain,\
-  t:lowercase,t:normalizePath,\
+  t:none,t:lowercase,t:normalizePath,\
   tag:'wordpress',\
   tag:'info-leak',\
   tag:'config-leak',\
@@ -136,7 +136,7 @@ SecRule TX:wphard.block_wpconfig_backups "@eq 1" \
   logdata:'Request URI %{REQUEST_URI}',\
   msg:'Wordpress hardening: wp-config backup variant probe'"
   SecRule REQUEST_URI "@rx ^/wp-config(?:\.php)?(?:\.(?:bak|backup|save|old|new|orig|tmp|swp|swo|txt|inc|dist|sample|copy|[0-9]+)|~)(?:$|\?)" \
-    "t:lowercase,t:normalizePath,\
+    "t:none,t:lowercase,t:normalizePath,\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # ----------------------------------------------------------------------------
@@ -150,7 +150,7 @@ SecRule TX:wphard.block_plugin_readme "@eq 1" \
   "id:9522115,\
   phase:1,\
   chain,\
-  t:lowercase,t:normalizePath,\
+  t:none,t:lowercase,t:normalizePath,\
   tag:'wordpress',\
   tag:'info-leak',\
   tag:'version-disclosure',\
@@ -162,7 +162,7 @@ SecRule TX:wphard.block_plugin_readme "@eq 1" \
   logdata:'Request URI %{REQUEST_URI}',\
   msg:'Wordpress hardening: plugin/theme version disclosure probe'"
   SecRule REQUEST_URI "@rx ^/wp-content/(?:plugins|themes|mu-plugins)/[^/]+/(?:readme(?:\.txt|\.md)|changelog\.txt|license\.txt)(?:$|\?)" \
-    "t:lowercase,t:normalizePath,\
+    "t:none,t:lowercase,t:normalizePath,\
     setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
 
 # ----------------------------------------------------------------------------
@@ -175,7 +175,7 @@ SecRule TX:wphard.block_uncommon_methods "@eq 1" \
   "id:9522119,\
   phase:1,\
   chain,\
-  t:lowercase,t:normalizePath,\
+  t:none,t:lowercase,t:normalizePath,\
   tag:'wordpress',\
   tag:'http-method',\
   tag:'paranoia-level/1',\
@@ -186,9 +186,11 @@ SecRule TX:wphard.block_uncommon_methods "@eq 1" \
   logdata:'Method %{REQUEST_METHOD} on %{REQUEST_URI}',\
   msg:'Wordpress hardening: uncommon HTTP method on WP path'"
   SecRule REQUEST_URI "@rx ^/(?:wp-admin/|wp-login\.php|xmlrpc\.php|wp-cron\.php)" \
-    "chain"
+    "t:none,t:lowercase,t:normalizePath,\
+    chain"
     SecRule REQUEST_METHOD "!@rx ^(?:GET|POST|HEAD|OPTIONS)$" \
-      "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+      "t:none,\
+      setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # ----------------------------------------------------------------------------
 # Legacy CVE scanner noise reduction. These plugins are long dead or patched
@@ -206,7 +208,7 @@ SecRule TX:wphard.block_legacy_cves "@eq 1" \
   "id:9522120,\
   phase:1,\
   chain,\
-  t:lowercase,t:normalizePath,t:urlDecodeUni,\
+  t:none,t:lowercase,t:normalizePath,t:urlDecodeUni,\
   tag:'wordpress',\
   tag:'legacy-cve',\
   tag:'paranoia-level/1',\
@@ -217,5 +219,5 @@ SecRule TX:wphard.block_legacy_cves "@eq 1" \
   logdata:'Legacy CVE probe: %{REQUEST_URI}',\
   msg:'Wordpress hardening: legacy CVE scanner probe'"
   SecRule REQUEST_URI "@rx (?:revslider_(?:show_image|ajax_action)|timthumb\.php|/wp-symposium/|/mailpoet/.*wysija[_-]?captcha|/wp-file-manager/.*connector\.minimal\.php|installer-backup\.php|installer\.php\?dup-uninstall)" \
-    "t:lowercase,t:normalizePath,t:urlDecodeUni,\
+    "t:none,t:lowercase,t:normalizePath,t:urlDecodeUni,\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"

--- a/plugins/wordpress-hardening-before.conf
+++ b/plugins/wordpress-hardening-before.conf
@@ -11,7 +11,7 @@
 # Plugin name: wordpress-hardening-plugin
 # Plugin description: harden wordpress, minimize php/sql impact
 # Rule ID block base: 9,522,000-9,522,999
-# Plugin version: 1.1.0
+# Plugin version: 1.2.0
 #
 # CONVENTION: severity:'NOTICE'/'WARNING' on blocking rules reflects log
 # importance, but every blocking rule still increments
@@ -352,7 +352,7 @@ SecRule REQUEST_HEADERS:CF-IPCountry "@rx ^[A-Za-z]{2}$" \
   id:9522500,\
   pass,\
   nolog,\
-  t:lowercase,\
+  t:none,t:lowercase,\
   setvar:tx.wphard.geoip_country=%{MATCHED_VAR}"
 
 SecRule &REQUEST_HEADERS:CF-IPCountry "@eq 0" \
@@ -362,7 +362,7 @@ SecRule &REQUEST_HEADERS:CF-IPCountry "@eq 0" \
   nolog,\
   chain"
   SecRule REQUEST_HEADERS:X-GeoIP-Country "@rx ^[A-Za-z]{2}$" \
-    "t:lowercase,\
+    "t:none,t:lowercase,\
     setvar:tx.wphard.geoip_country=%{MATCHED_VAR}"
 
 # ─── TRUSTED CLIENT IP RESOLUTION (phase 1) ─────────────────────────────────
@@ -462,7 +462,7 @@ SecRule TX:wphard.xff_trusted "@eq 1" \
 # regexes into a single check, and gives every group an IPv6-aware
 # private-network test for free.
 #
-# t:lowercase normalises hex casing on IPv6 values, allowing the regex to
+# t:none,t:lowercase normalises hex casing on IPv6 values, allowing the regex to
 # stay plain-ASCII without [fF][cCdD] case-class noise.
 #
 # The ::ffff:<v4> branch is required because dual-stack proxies forward
@@ -474,7 +474,7 @@ SecRule TX:wphard.client_ip "@rx ^(?:127\.[0-9]+\.[0-9]+\.[0-9]+|10\.[0-9]+\.[0-
   phase:1,\
   pass,\
   nolog,\
-  t:lowercase,\
+  t:none,t:lowercase,\
   setvar:tx.wphard.client_is_private=1"
 # ----------------------------------------------------------------------------
 # Phase:1 anomaly-scoring rules (9522100, 9522112-9522115, 9522119, 9522120)
@@ -506,10 +506,9 @@ SecRule TX:wphard.block_php_wrappers "@eq 1" \
   severity:'CRITICAL',\
   ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Matched %{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
   msg:'Wordpress hardening: PHP stream wrapper / LFI-RFI probe'"
-  SecRule ARGS|REQUEST_URI "@rx (?:^|[^a-z0-9])(?:php|data|expect|file|phar|glob|zip|compress\.(?:zlib|bzip2))://" \
+  SecRule ARGS_NAMES|ARGS|REQUEST_URI "@rx (?:^|[^a-z0-9])(?:php|data|expect|file|phar|glob|zip|compress\.(?:zlib|bzip2))://" \
     "t:none,t:urlDecodeUni,t:urlDecodeUni,t:lowercase,\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
@@ -527,37 +526,39 @@ SecRule TX:wphard.block_known_plugin_cves "@eq 1" \
   "id:9522117,\
   phase:2,\
   chain,\
-  t:lowercase,t:normalizePath,\
+  t:none,t:lowercase,t:normalizePath,\
   tag:'wordpress',\
   tag:'known-cve',\
   tag:'suretriggers',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'CRITICAL',\
-  ver:'WPHARD/1.0.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
   logdata:'SureTriggers REST probe: %{REQUEST_URI}',\
   msg:'Wordpress hardening: SureTriggers/OttoKit CVE-2025-3102/27007 probe'"
   SecRule REQUEST_URI "@rx ^/(?:index\.php\?rest_route=/?|wp-json/)sure-triggers/v1/" \
-    "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    "t:none,t:lowercase,t:normalizePath,\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 SecRule TX:wphard.block_known_plugin_cves "@eq 1" \
   "id:9522118,\
   phase:2,\
   chain,\
-  t:lowercase,\
+  t:none,t:lowercase,\
   tag:'wordpress',\
   tag:'known-cve',\
   tag:'bricks-builder',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'CRITICAL',\
-  ver:'WPHARD/1.0.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
   logdata:'Bricks render_element probe: %{REQUEST_URI}',\
   msg:'Wordpress hardening: Bricks Builder CVE-2024-25600 RCE probe'"
   SecRule REQUEST_URI "@rx ^/(?:index\.php\?rest_route=/?|wp-json/)bricks/v1/render_element" \
-    "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+    "t:none,t:lowercase,t:normalizePath,\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # ----------------------------------------------------------------------------
 # Rules 9522119 (uncommon HTTP methods) and 9522120 (legacy CVE scanners)
@@ -598,13 +599,13 @@ SecRule TX:wphard.block_breach_compression "@eq 1" \
   "id:9522121,\
   phase:1,\
   chain,\
-  t:lowercase,t:normalizePath,\
+  t:none,t:lowercase,t:normalizePath,\
   tag:'wordpress',\
   tag:'breach',\
   tag:'crime',\
   tag:'compression-side-channel',\
   tag:'paranoia-level/1',\
-  ver:'WPHARD/1.0.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   pass,\
   log,\
   auditlog,\
@@ -638,15 +639,14 @@ SecMarker "BEGIN_WPHARD_XMLRPC"
 SecRule REQUEST_FILENAME "^/xmlrpc\.php" \
   "id:9522102,\
   phase:2,\
-  t:lowercase,t:normalizePath,t:trim,\
+  t:none,t:lowercase,t:normalizePath,t:trim,\
   tag:'wordpress',\
   tag:'xmlrpc',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
   msg:'Wordpress hardening: xmlrpc.php access attempt',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -679,15 +679,14 @@ SecMarker "BEGIN_WPHARD_USER_ENUMERATION"
 SecRule REQUEST_URI "@rx (?:[/?&]author=[0-9]+)|(?:/wp/v2/users/?(?:\?|$))|(?:/wp/v2/users/[0-9]+)" \
   "id:9522104,\
   phase:2,\
-  t:lowercase,t:normalizePath,t:trim,t:urlDecodeUni,\
+  t:none,t:lowercase,t:normalizePath,t:trim,t:urlDecodeUni,\
   tag:'wordpress',\
   tag:'enumeration',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Request URI %{REQUEST_URI}',\
   msg:'Wordpress hardening: user enumeration detected',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -705,14 +704,14 @@ SecRule TX:wphard.block_author_archives "@eq 1" \
   "id:9522122,\
   phase:2,\
   chain,\
-  t:lowercase,t:normalizePath,t:trim,t:urlDecodeUni,\
+  t:none,t:lowercase,t:normalizePath,t:trim,t:urlDecodeUni,\
   tag:'wordpress',\
   tag:'enumeration',\
   tag:'author-archive',\
   tag:'paranoia-level/2',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.0.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
   logdata:'Request URI %{REQUEST_URI}',\
   msg:'Wordpress hardening: /author/ archive access blocked'"
@@ -742,16 +741,15 @@ SecMarker "BEGIN_WPHARD_BLOCK_REST_API"
 SecRule REQUEST_FILENAME "@rx ^/wp-json/.+" \
   "id:9522107,\
   phase:2,\
-  t:lowercase,t:normalizePath,\
+  t:none,t:lowercase,t:normalizePath,\
   tag:'wordpress',\
   tag:'rest-api',\
   tag:'wp-json',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Request FILENAME %{REQUEST_FILENAME}',\
   msg:'Wordpress hardening: /wp-json rest api access detected',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -771,20 +769,19 @@ SecMarker "BEGIN_WPHARD_BLOCK_ADMIN_LOGIN"
 SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
   "id:9522109,\
   phase:2,\
-  t:lowercase,t:normalizePath,t:trim,\
+  t:none,t:lowercase,t:normalizePath,t:trim,\
   tag:'wordpress',\
   tag:'admin-login',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'WARNING',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Matched %{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
   msg:'Wordpress hardening: admin login attempt detected',\
     chain"
     SecRule ARGS:log|ARGS:pwd "@streq admin" \
-    "t:lowercase,t:trim,\
+    "t:none,t:lowercase,t:trim,\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 SecMarker "END_WPHARD_BLOCK_ADMIN_LOGIN"
@@ -812,15 +809,14 @@ SecMarker "BEGIN_WPHARD_WPCRON"
 SecRule REQUEST_FILENAME "^/wp-cron\.php" \
   "id:9522111,\
   phase:2,\
-  t:lowercase,t:normalizePath,t:trim,\
+  t:none,t:lowercase,t:normalizePath,t:trim,\
   tag:'wordpress',\
   tag:'wpcron',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
   msg:'Wordpress hardening: /wp-cron.php access attempt',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -841,7 +837,7 @@ SecMarker "END_WPHARD_WPCRON"
 SecRule REQUEST_FILENAME "@rx \.(?:jpe?g|png|gif|webp|svg|ico|css|js|map|woff2?|ttf|eot|avif|mp4|webm)$" \
   "id:9522199,\
   phase:2,\
-  t:lowercase,t:normalizePath,t:trim,\
+  t:none,t:lowercase,t:normalizePath,t:trim,\
   pass,\
   nolog,\
   skipAfter:END_WPHARD_STATIC_FILE_RULES"
@@ -860,35 +856,33 @@ SecRule REQUEST_FILENAME "@rx \.(?:jpe?g|png|gif|webp|svg|ico|css|js|map|woff2?|
 SecRule REQUEST_FILENAME "@rx \.php$" \
   "id:9522200,\
   phase:2,\
-  t:lowercase,t:normalizePath,t:trim,\
+  t:none,t:lowercase,t:normalizePath,t:trim,\
   tag:'wordpress',\
   tag:'direct-access',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
   msg:'Wordpress hardening: attempt to access php files other than index.php',\
   chain"
   SecRule REQUEST_FILENAME "!@rx ^(?:/wp-admin/|/(?:index|xmlrpc|wp-cron|wp-login|wp-comments-post|wp-signup)\.php$)" \
-    "t:lowercase,t:normalizePath,t:trim,\
+    "t:none,t:lowercase,t:normalizePath,t:trim,\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 # No direct access to these files (PL1)
 SecRule REQUEST_FILENAME "@pmFromFile wordpress-hardening-files.data" \
   "id:9522202,\
   phase:2,\
-  t:lowercase,t:normalizePath,t:trim,\
+  t:none,t:lowercase,t:normalizePath,t:trim,\
   tag:'wordpress',\
   tag:'direct-access',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
   msg:'Wordpress hardening: direct file access attempt on files that dont need that',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -907,15 +901,14 @@ SecMarker "BEGIN_WPHARD_OTHER_INTERPRETERS"
 SecRule REQUEST_FILENAME "@rx \.(?:pl|cgi|py|sh|lua|aspx?)$" \
   "id:9522203,\
   phase:2,\
-  t:lowercase,t:normalizePath,t:trim,\
+  t:none,t:lowercase,t:normalizePath,t:trim,\
   tag:'wordpress',\
   tag:'only-allow-php-extension',\
   tag:'paranoia-level/2',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
   msg:'Wordpress hardening: trying another interpreter',\
   setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -926,15 +919,14 @@ SecMarker "END_WPHARD_OTHER_INTERPRETERS"
 SecRule REQUEST_FILENAME "@rx ^/wp-content/uploads/.*\.(?:s?html?|swf|lua)$" \
   "id:9522205,\
   phase:2,\
-  t:lowercase,t:normalizePath,t:trim,\
+  t:none,t:lowercase,t:normalizePath,t:trim,\
   tag:'wordpress',\
   tag:'uploads',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
   msg:'Wordpress hardening: attempt to access wp-content/uploads nasty stuff',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -943,15 +935,14 @@ SecRule REQUEST_FILENAME "@rx ^/wp-content/uploads/.*\.(?:s?html?|swf|lua)$" \
 SecRule REQUEST_FILENAME "@rx \.(?:conf|htaccess|htpass|sql|orig|bak|db|ini|md|log|git|github|swp|ds_store)(?:$|/)" \
   "id:9522206,\
   phase:2,\
-  t:lowercase,t:normalizePath,t:trim,\
+  t:none,t:lowercase,t:normalizePath,t:trim,\
   tag:'wordpress',\
   tag:'sensitive-files',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
   msg:'Wordpress hardening: denied access to sensitive files',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -972,16 +963,15 @@ SecMarker "BEGIN_WPHARD_BLOCK_REST_API_ROOT"
 SecRule REQUEST_FILENAME "@rx ^/wp-json/?$" \
   "id:9522207,\
   phase:2,\
-  t:lowercase,t:normalizePath,t:trim,\
+  t:none,t:lowercase,t:normalizePath,t:trim,\
   tag:'wordpress',\
   tag:'sensitive-files',\
   tag:'wp-json',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
   msg:'Wordpress hardening: denied access to ^/wp-json$',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -1002,15 +992,14 @@ SecMarker "BEGIN_WPHARD_BLOCK_EDITOR_ACCESS"
 SecRule REQUEST_FILENAME "@rx ^/wp-admin/(theme|plugin)-editor\.php" \
   "id:9522301,\
   phase:2,\
-  t:lowercase,t:normalizePath,t:trim,\
+  t:none,t:lowercase,t:normalizePath,t:trim,\
   tag:'wordpress',\
   tag:'editor-access',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
   msg:'Wordpress hardening: access to wp-admin theme/plugin editor blocked',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -1036,15 +1025,14 @@ SecMarker "BEGIN_WPHARD_BLOCK_BACKUP_FILES"
 SecRule REQUEST_FILENAME "@rx ^/(?:backups?|db-backup|site-backup|wordpress-backup|backup-db)/|/wp-content/(?:backups?|backup)/|[-_]backup[-_][^/]*\.(?:zip|tar(?:\.(?:gz|bz2|xz))?|tgz|sql(?:\.(?:gz|bz2|zip))?|dump|bak)(?:$|/)|\.(?:tar\.gz|tar\.bz2|tgz)(?:$|/)" \
   "id:9522303,\
   phase:2,\
-  t:lowercase,t:normalizePath,t:trim,\
+  t:none,t:lowercase,t:normalizePath,t:trim,\
   tag:'wordpress',\
   tag:'backup-files',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
   msg:'Wordpress hardening: access to backup directory or archive blocked',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -1065,15 +1053,14 @@ SecMarker "BEGIN_WPHARD_BLOCK_DB_FILES"
 SecRule REQUEST_FILENAME "@rx (?:\.(?:sql\.gz|sql\.bz2|sql\.zip|dump\.sql)|(?:^|[/_-])mysqldump[^/]*\.sql)(?:$|/|\?)" \
   "id:9522305,\
   phase:2,\
-  t:lowercase,t:normalizePath,t:trim,\
+  t:none,t:lowercase,t:normalizePath,t:trim,\
   tag:'wordpress',\
   tag:'database-files',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
   msg:'Wordpress hardening: access to compressed database export blocked',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -1100,15 +1087,14 @@ SecMarker "BEGIN_WPHARD_BLOCK_UPLOAD_TRAVERSAL"
 SecRule REQUEST_URI "@rx /wp-content/uploads/[^?]*\.\." \
   "id:9522307,\
   phase:2,\
-  t:lowercase,t:urlDecodeUni,t:trim,\
+  t:none,t:lowercase,t:urlDecodeUni,t:trim,\
   tag:'wordpress',\
   tag:'upload-traversal',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Request URI %{REQUEST_URI}',\
   msg:'Wordpress hardening: directory traversal in uploads path blocked',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -1154,9 +1140,8 @@ SecRule REQUEST_URI|ARGS_NAMES|ARGS|REQUEST_BODY "@rx %(?:25)*00|%u0000" \
   tag:'paranoia-level/2',\
   maturity:'1',\
   severity:'CRITICAL',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Matched Data: %{MATCHED_VAR} in %{MATCHED_VAR_NAME}',\
   msg:'Wordpress hardening: null byte injection attempt blocked',\
   setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1185,15 +1170,14 @@ SecRule TX:detection_paranoia_level "@lt 2" \
 SecRule REQUEST_HEADERS:User-Agent "@pmFromFile wordpress-hardening-scanners.data" \
   "id:9522311,\
   phase:2,\
-  t:lowercase,\
+  t:none,t:lowercase,\
   tag:'wordpress',\
   tag:'scanner',\
   tag:'paranoia-level/2',\
   maturity:'1',\
   severity:'WARNING',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'User-Agent: %{REQUEST_HEADERS.User-Agent}',\
   msg:'Wordpress hardening: known security scanner user agent blocked',\
   setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1215,22 +1199,21 @@ SecMarker "BEGIN_WPHARD_BLOCK_DEBUG_PROBES"
 # the word triggered the block. Anchor it to either an exact arg-name match or
 # a /phpinfo(.php)? URI segment so legitimate content slugs are not blocked.
 #
-# Regex literals are lowercase because the rule applies t:lowercase to the
-# input. The earlier form used uppercase XDEBUG_* literals after t:lowercase
+# Regex literals are lowercase because the rule applies t:none,t:lowercase to the
+# input. The earlier form used uppercase XDEBUG_* literals after t:none,t:lowercase
 # and therefore never matched the very payloads it was meant to block
 # (AUDIT-ROUND-5.md §1-P0).
 SecRule REQUEST_URI|ARGS_NAMES "@rx (?:xdebug_session(?:_(?:start|stop))?|xdebug_profile|xdebug_trace|(?:^|/)phpinfo(?:\.php)?(?:$|[/?])|(?:^|&)phpinfo(?:=|$))" \
   "id:9522313,\
   phase:2,\
-  t:lowercase,t:urlDecodeUni,\
+  t:none,t:lowercase,t:urlDecodeUni,\
   tag:'wordpress',\
   tag:'debug-probe',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Matched Data: %{MATCHED_VAR} in %{MATCHED_VAR_NAME}',\
   msg:'Wordpress hardening: debug probe or XDebug activation attempt blocked',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -1251,20 +1234,19 @@ SecMarker "BEGIN_WPHARD_BLOCK_LOGIN_INJECTION"
 SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
   "id:9522315,\
   phase:2,\
-  t:lowercase,t:normalizePath,t:trim,\
+  t:none,t:lowercase,t:normalizePath,t:trim,\
   tag:'wordpress',\
   tag:'login-injection',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'CRITICAL',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Matched injection in login param: %{MATCHED_VAR}',\
   msg:'Wordpress hardening: code injection detected in wp-login.php parameters',\
   chain"
   SecRule ARGS:log|ARGS:pwd "@rx (?:<[^>]+>|script|alert\(|eval\(|base64_decode|onload=|onerror=)" \
-    "t:lowercase,t:htmlEntityDecode,t:urlDecodeUni,\
+    "t:none,t:lowercase,t:htmlEntityDecode,t:urlDecodeUni,\
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 
 SecMarker "END_WPHARD_BLOCK_LOGIN_INJECTION"
@@ -1303,7 +1285,6 @@ SecRule TX:wphard.block_orderby_injection "@eq 1" \
   severity:'CRITICAL',\
   ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Matched %{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
   msg:'Wordpress hardening: ORDER BY direction injection (order param not asc/desc)'"
   SecRule ARGS_GET:order|ARGS_POST:order "!@rx ^\s*(?i:asc|desc)?\s*$" \
@@ -1326,7 +1307,6 @@ SecRule TX:wphard.block_orderby_injection "@eq 1" \
   severity:'CRITICAL',\
   ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Matched %{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
   msg:'Wordpress hardening: ORDER BY column injection (SQL metachar in orderby)'"
   SecRule ARGS_GET:orderby|ARGS_POST:orderby "@rx ['\x22();]|--|/\*|\b(?:union|select|sleep|benchmark|concat|case|when|having|group_concat|information_schema|substring|ascii|extractvalue|updatexml|if)\b" \
@@ -1348,7 +1328,6 @@ SecRule TX:wphard.block_orderby_injection "@eq 1" \
   severity:'CRITICAL',\
   ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Matched %{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
   msg:'Wordpress hardening: orderby not a plain column name (PL2 strict)'"
   SecRule TX:detection_paranoia_level "@ge 2" "chain"
@@ -1374,7 +1353,6 @@ SecRule TX:wphard.block_numeric_param_injection "@eq 1" \
   severity:'CRITICAL',\
   ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Matched %{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
   msg:'Wordpress hardening: non-integer value in WP-core numeric query-var'"
   SecRule ARGS_GET:p|ARGS_GET:page_id|ARGS_GET:attachment_id|ARGS_GET:m|ARGS_GET:w|ARGS_GET:year|ARGS_GET:monthnum|ARGS_GET:day|ARGS_GET:hour|ARGS_GET:minute|ARGS_GET:paged|ARGS_GET:cpage "!@rx ^[0-9]*$" \
@@ -1397,7 +1375,6 @@ SecRule TX:wphard.strict_integer_params "@eq 1" \
   severity:'CRITICAL',\
   ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Matched %{MATCHED_VAR_NAME}=%{MATCHED_VAR}',\
   msg:'Wordpress hardening: non-integer value in strict-typed plugin id param'"
   SecRule TX:detection_paranoia_level "@ge 2" "chain"
@@ -1429,15 +1406,14 @@ SecRule TX:detection_paranoia_level "@lt 2" \
 SecRule REQUEST_FILENAME "@rx ^/wp-admin/(upgrade|wp-activate)\.php" \
   "id:9522317,\
   phase:2,\
-  t:lowercase,t:normalizePath,t:trim,\
+  t:none,t:lowercase,t:normalizePath,t:trim,\
   tag:'wordpress',\
   tag:'dangerous-admin',\
   tag:'paranoia-level/2',\
   maturity:'1',\
   severity:'NOTICE',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Request Filename %{REQUEST_FILENAME}',\
   msg:'Wordpress hardening: access to dangerous wp-admin endpoint blocked',\
   setvar:'tx.inbound_anomaly_score_pl2=+%{tx.critical_anomaly_score}'"
@@ -1481,7 +1457,7 @@ SecRule REQUEST_FILENAME "!@endsWith /wp-login.php" \
   phase:2,\
   pass,\
   nolog,\
-  t:lowercase,t:normalizePath,\
+  t:none,t:lowercase,t:normalizePath,\
   skipAfter:END_WPHARD_GEOIP_LOGIN"
 
 # Whitelist: skip GeoIP check for the resolved trusted client IP if it is
@@ -1515,9 +1491,8 @@ SecRule TX:wphard.geoip_country "@rx ^[A-Za-z]{2}$" \
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'WARNING',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Country: %{tx.wphard.geoip_country}, URI: %{REQUEST_URI}',\
   msg:'Wordpress hardening: wp-login.php blocked for country %{tx.wphard.geoip_country}',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -1567,9 +1542,8 @@ SecRule TX:wphard.client_ip "@ipMatchFromFile wordpress-hardening-ip-reputation.
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'CRITICAL',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   block,\
-  capture,\
   logdata:'Blocked client IP: %{tx.wphard.client_ip}, URI: %{REQUEST_URI}',\
   msg:'Wordpress hardening: request from IP reputation blocklist',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
@@ -1620,7 +1594,7 @@ SecRule RESPONSE_HEADERS:X-Pingback "@rx ^" \
   tag:'wordpress',\
   tag:'version-disclosure',\
   tag:'paranoia-level/1',\
-  ver:'WPHARD/1.0.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   pass,\
   log,\
   auditlog,\
@@ -1634,7 +1608,7 @@ SecRule RESPONSE_HEADERS:X-Powered-By "@rx (?i)wordpress|php" \
   tag:'wordpress',\
   tag:'version-disclosure',\
   tag:'paranoia-level/1',\
-  ver:'WPHARD/1.0.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   pass,\
   log,\
   auditlog,\
@@ -1648,7 +1622,7 @@ SecRule RESPONSE_HEADERS:Link "@rx api\.w\.org" \
   tag:'wordpress',\
   tag:'version-disclosure',\
   tag:'paranoia-level/1',\
-  ver:'WPHARD/1.0.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   pass,\
   log,\
   auditlog,\
@@ -1696,13 +1670,13 @@ SecMarker "BEGIN_WPHARD_RESPONSE_953_FP"
 SecRule REQUEST_FILENAME "!@rx ^/(?:wp-admin(?:/|$|\?)|wp-login\.php|xmlrpc\.php|wp-cron\.php|wp-json(?:/|$|\?)|wp-content/|wp-includes/)" \
   "id:9522801,\
   phase:1,\
-  t:lowercase,t:normalizePath,\
+  t:none,t:lowercase,t:normalizePath,\
   pass,\
   nolog,\
   tag:'wordpress',\
   tag:'OWASP_CRS',\
   tag:'paranoia-level/1',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   chain"
   SecRule REQUEST_URI "!@rx (?i)[?&]rest_route=" \
     "t:none,\

--- a/plugins/wordpress-hardening-config.conf
+++ b/plugins/wordpress-hardening-config.conf
@@ -11,7 +11,7 @@
 # Plugin name: wordpress-hardening-plugin
 # Plugin description: harden wordpress, minimize php/sql impact
 # Rule ID block base: 9,522,000-9,522,999
-# Plugin version: 1.0.0
+# Plugin version: 1.2.0
 
 # Generic rule to disable the plugin
 # Plugins are enabled by default.
@@ -124,19 +124,16 @@
 # Lock out an IP after X failed login attempts within a fixed 60-second window.
 # Default: 5 attempts per 60 seconds, whitelist: localhost + RFC 1918.
 #
-# WINDOW VALUES — choose one of: 30, 60, 120, 300, 600 (seconds).
-# expirevar does not accept macros, so the plugin dispatches on the configured
-# value through five literal expirevar rules (9522416-9522420). Any other value
-# silently falls back to 60s. The active window is logged in the 9522412 block
-# message and emitted as the wphard_retry_after env var (consumable by the
-# webserver to add a Retry-After response header).
+# WINDOW is fixed at 60 seconds and NOT configurable: expirevar does not accept
+# a macro TTL. The window is emitted as the wphard_retry_after env var (=60),
+# consumable by the webserver to add a Retry-After: 60 response header.
 #
-# To override defaults, uncomment lines below and adjust values as needed.
+# Only the attempt threshold is tunable. To override, uncomment below.
 #
 # Example: Disable rate limiting entirely
 #SecAction "id:9522048,phase:1,nolog,pass,t:none,setvar:'tx.wphard.ratelimit_login_enabled=0'"
 #
-# Example: Reduce threshold to 3 attempts (window stays 60s — see note above)
+# Example: Reduce threshold to 3 attempts (window is always 60s)
 #SecAction "id:9522049,phase:1,nolog,pass,t:none,setvar:'tx.wphard.ratelimit_login_attempts=3'"
 #SecAction "id:9522051,phase:1,nolog,pass,t:none,setvar:'tx.wphard.ratelimit_login_whitelist_ips=127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 203.0.113.0/24'"
 

--- a/plugins/wordpress-hardening-files.data
+++ b/plugins/wordpress-hardening-files.data
@@ -3,7 +3,7 @@
 /imagify-backup/
 /license.txt
 /nginx.conf
-/readme
+/readme.
 /wlwmanifest.xml
 /wp-activate.php
 /wp-config

--- a/plugins/wordpress-hardening-ratelimit.conf
+++ b/plugins/wordpress-hardening-ratelimit.conf
@@ -73,11 +73,11 @@ SecRule REQUEST_METHOD "@streq POST" \
     "t:lowercase,t:normalizePath,\
     initcol:ip=%{tx.wphard.client_ip}"
 
-# Track login attempts: increment the per-client counter on POST to wp-login.
-# expirevar cannot take a macro TTL, so we dispatch on the configured window
-# value to one of five well-known buckets (30/60/120/300/600 seconds). Any
-# other value falls back to 60s. This honours tx.wphard.ratelimit_login_window
-# end-to-end instead of silently ignoring it.
+# Track login attempts: increment the per-client counter on POST to wp-login
+# and (re)arm the 60-second expiry. The window is fixed at 60s: expirevar
+# cannot take a macro TTL, so there is no configurable window variable (a prior
+# tx.wphard.ratelimit_login_window tunable was removed — it never affected
+# behaviour). See wordpress-hardening-before.conf.
 SecRule REQUEST_METHOD "@streq POST" \
   "id:9522411,\
   phase:2,\
@@ -91,23 +91,7 @@ SecRule REQUEST_METHOD "@streq POST" \
   SecRule REQUEST_FILENAME "@endsWith /wp-login.php" \
     "t:lowercase,t:normalizePath,\
     setvar:ip.login_attempts=+1,\
-    capture"
-
-# Window dispatcher. Each @streq is a literal so no macro is needed; the
-# rule fires only when the configured window matches that bucket, sets the
-# expirevar accordingly, and skips the rest. The trailing SecAction handles
-# the 60s default + any unknown value.
-SecRule TX:wphard.ratelimit_login_window "@streq 30" \
-  "id:9522416,phase:2,pass,nolog,expirevar:ip.login_attempts=30,skipAfter:END_WPHARD_WINDOW_DISPATCH"
-SecRule TX:wphard.ratelimit_login_window "@streq 120" \
-  "id:9522417,phase:2,pass,nolog,expirevar:ip.login_attempts=120,skipAfter:END_WPHARD_WINDOW_DISPATCH"
-SecRule TX:wphard.ratelimit_login_window "@streq 300" \
-  "id:9522418,phase:2,pass,nolog,expirevar:ip.login_attempts=300,skipAfter:END_WPHARD_WINDOW_DISPATCH"
-SecRule TX:wphard.ratelimit_login_window "@streq 600" \
-  "id:9522419,phase:2,pass,nolog,expirevar:ip.login_attempts=600,skipAfter:END_WPHARD_WINDOW_DISPATCH"
-SecAction \
-  "id:9522420,phase:2,pass,nolog,expirevar:ip.login_attempts=60"
-SecMarker "END_WPHARD_WINDOW_DISPATCH"
+    expirevar:ip.login_attempts=60"
 
 # Block if login attempts exceed threshold for this client IP
 # RFC 6585 §4: rate-limit responses SHOULD use 429 Too Many Requests, not the
@@ -117,17 +101,16 @@ SecMarker "END_WPHARD_WINDOW_DISPATCH"
 SecRule IP:login_attempts "@ge %{tx.wphard.ratelimit_login_attempts}" \
   "id:9522412,\
   phase:2,\
-  t:lowercase,t:normalizePath,\
+  t:none,t:lowercase,t:normalizePath,\
   tag:'wordpress',\
   tag:'rate-limit',\
   tag:'paranoia-level/1',\
   maturity:'1',\
   severity:'WARNING',\
-  ver:'WPHARD/1.1.0',\
+  ver:'wordpress-hardening-plugin/1.2.0',\
   deny,status:429,\
-  capture,\
-  setenv:'wphard_retry_after=%{tx.wphard.ratelimit_login_window}',\
-  logdata:'Client IP: %{tx.wphard.client_ip}, Attempts: %{IP:login_attempts}, Threshold: %{tx.wphard.ratelimit_login_attempts}, Window: %{tx.wphard.ratelimit_login_window}s',\
+  setenv:'wphard_retry_after=60',\
+  logdata:'Client IP: %{tx.wphard.client_ip}, Attempts: %{IP:login_attempts}, Threshold: %{tx.wphard.ratelimit_login_attempts}, Window: 60s',\
   msg:'Wordpress hardening: wp-login.php rate limit exceeded for IP',\
   setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 

--- a/plugins/wordpress-hardening-scanners.data
+++ b/plugins/wordpress-hardening-scanners.data
@@ -52,4 +52,3 @@ petalbot
 rogerbot
 seokicks
 siteauditbot
-facebookexternalhit/scanner


### PR DESCRIPTION
Audit sweep (waf-rulesets skill).

## MAJOR — dead rate-limit window / broken Retry-After
`tx.wphard.ratelimit_login_window` was set/defaulted **nowhere** (before.conf documents the tunable as removed), yet `ratelimit.conf` still read it six times: dispatcher `9522416`-`9522419` never matched the unset var → always 60s fallback; `9522412` logdata printed `Window: s`; `setenv:wphard_retry_after` emitted empty → blank `Retry-After`. Collapsed to fixed 60s: dropped dispatcher + marker, folded `expirevar=60` into the `9522411` tick, hardcoded `setenv=60`, rewrote the config.conf doc block.

## MINOR
- Chain-link case/transform evasion `9522117`/`9522118`/`9522119` — child `REQUEST_URI` matches lacked `t:none,t:lowercase,t:normalizePath`; `/WP-JSON/...` / `/WP-ADMIN/` bypassed the CVE + method blocks (same root cause as `9522116`). Added transforms.
- `9522116`: added `ARGS_NAMES`. `9522311`: dropped unused `capture`.

## NIT
Leading `t:none` on detection rules; normalized `ver:` + file headers to `wordpress-hardening-plugin/1.2.0`; removed redundant `capture`; `files.data` `/readme`→`/readme.`; removed dead `facebookexternalhit/scanner` entry.

## Validation
Local CI green (secrules-parsing ×4, go-ftw check 49, marker/gate coverage); coraza probe loads before/after/config on all three engines.